### PR TITLE
topology-migrator-experiment

### DIFF
--- a/docs/wolverine-subscriptions.md
+++ b/docs/wolverine-subscriptions.md
@@ -1,0 +1,35 @@
+# Subscription mechanics wolverine:
+
+apikey.subscriptions (quorum queue)
+	x-dead-letter-exchange:	apikey.subscriptions.dlq
+	arguments:	
+		x-queue-type:	quorum
+	durable:	true
+	binding to sso.authz.events with user-roles-changed routeKey
+
+apikey.subscriptions.dlq (exchange)
+	Type 	topic
+	Features 	
+		durable:	true
+	binding to apikey.subscriptions.dlq with apikey.subscriptions.dlq routeKey
+	
+apikey.subscriptions.dlq (classic queue)
+	x-dead-letter-exchange:	apikey.wolverine-dead-letter-queue
+	arguments:	
+		x-queue-type:	classic
+	durable:	true
+	queue storage version:	2
+	binding to apikey.subscriptions.dlq with apikey.subscriptions.dlq routeKey
+	
+apikey.wolverine-dead-letter-queue (exchange)
+	Type 	fanout
+	Features 	
+		durable:	true
+	binding to apikey.wolverine-dead-letter-queue with apikey.wolverine-dead-letter-queue routeKey
+	
+apikey.wolverine-dead-letter-queue (classic queue)
+	arguments:	
+		x-queue-type:	classic
+	durable:	true
+	queue storage version:	2
+	binding to apikey.wolverine-dead-letter-queue with apikey.wolverine-dead-letter-queue routeKey

--- a/src/Ratatoskr.RabbitMq/Extensions/RabbitMqRatatoskrBuilderExtensions.cs
+++ b/src/Ratatoskr.RabbitMq/Extensions/RabbitMqRatatoskrBuilderExtensions.cs
@@ -15,6 +15,7 @@ public static class RabbitMqRatatoskrBuilderExtensions
         builder.Services.AddSingleton<RabbitMqConnectionManager>();
         builder.Services.AddSingleton<IRabbitMqEnvelopeMapper, CloudEventsAmqpMapper>();
         builder.Services.AddSingleton<RabbitMqTopologyManager>();
+        builder.Services.AddSingleton<TopologyMigrator>();
         
         // Sending
         builder.Services.AddSingleton<ITransportMessageMetadataEnricher, RabbitMqMessageMetadataEnricher>();

--- a/src/Ratatoskr.RabbitMq/RabbitMqOptions.cs
+++ b/src/Ratatoskr.RabbitMq/RabbitMqOptions.cs
@@ -30,4 +30,9 @@ public class RabbitMqOptions
     /// Timeout for publisher confirms
     /// </summary>
     public TimeSpan PublisherConfirmTimeout { get; set; } = TimeSpan.FromSeconds(5);
+    
+    /// <summary>
+    /// Whether to automatically migrate topology (e.g., Classic -> Quorum queues)
+    /// </summary>
+    public bool AutoMigrateTopology { get; set; } = false;
 }

--- a/src/Ratatoskr.RabbitMq/TopologyMigrator.cs
+++ b/src/Ratatoskr.RabbitMq/TopologyMigrator.cs
@@ -1,0 +1,381 @@
+using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Exceptions;
+
+namespace Ratatoskr.RabbitMq;
+
+/// <summary>
+/// Handles safe migration of RabbitMQ topology (queues and exchanges) when configuration changes.
+/// </summary>
+/// <remarks>
+/// SAFETY FEATURES:
+/// - Creates backup queues before deleting originals
+/// - Multiple shovel passes to catch race conditions
+/// - Message count validation at each step
+/// - Preserves backup queue if migration fails after original deletion
+/// - Never deletes backup queue containing messages
+/// 
+/// LIMITATIONS:
+/// - Cannot prevent message loss from concurrent publishers during migration
+/// - Exchange migrations lose all bindings (must be recreated)
+/// - Best practice: Pause producers/consumers before migration
+/// 
+/// RECOVERY:
+/// - Failed migrations leave backup queues for manual recovery
+/// - Check logs for specific failure stage and message counts
+/// - Backup queues are named: {originalQueue}.backup
+/// </remarks>
+public class TopologyMigrator(
+    RabbitMqConnectionManager connectionManager,
+    ILogger<TopologyMigrator> logger)
+{
+    private const string BackupSuffix = ".backup";
+
+    public async Task EnsureQueueMigrationAsync(
+        string queueName, 
+        IDictionary<string, object?> targetArgs,
+        CancellationToken cancellationToken)
+    {
+        // 1. Check if migration is needed
+        bool migrationNeeded = false;
+        try
+        {
+            await using var checkChannel = await connectionManager.CreateChannelAsync(true, cancellationToken);
+            // Try to declare with target arguments to see if it matches
+            await checkChannel.QueueDeclareAsync(
+                queue: queueName,
+                durable: true,
+                exclusive: false,
+                autoDelete: false,
+                arguments: targetArgs,
+                cancellationToken: cancellationToken);
+        }
+        catch (OperationInterruptedException ex) when (ex.ShutdownReason?.ReplyCode == 406)
+        {
+            logger.LogWarning("Queue '{Queue}' mismatch detected. Initiating migration...", queueName);
+            migrationNeeded = true;
+        }
+
+        if (migrationNeeded)
+        {
+            await MigrateQueueInternalAsync(queueName, targetArgs, cancellationToken);
+        }
+    }
+
+    private async Task MigrateQueueInternalAsync(
+        string queueName,
+        IDictionary<string, object?> targetArgs,
+        CancellationToken cancellationToken)
+    {
+        var backupQueueName = $"{queueName}{BackupSuffix}";
+        
+        await using var channel = await connectionManager.CreateChannelAsync(true, cancellationToken);
+
+        // Track migration state for recovery decisions
+        bool backupQueueCreated = false;
+        bool originalQueueDeleted = false;
+        bool newQueueCreated = false;
+        uint initialMessageCount = 0;
+        int movedToBackup = 0;
+
+        try
+        {
+            // 0. Verify backup queue doesn't already exist
+            try
+            {
+                var existing = await channel.QueueDeclarePassiveAsync(backupQueueName, cancellationToken);
+                throw new InvalidOperationException(
+                    $"Backup queue '{backupQueueName}' already exists with {existing.MessageCount} messages. " +
+                    "This may indicate a previous failed migration. Manual recovery required: " +
+                    "1) Check if messages are valid, 2) Manually restore or delete backup queue.");
+            }
+            catch (OperationInterruptedException ex) when (ex.ShutdownReason?.ReplyCode == 404)
+            {
+                // Good - backup queue doesn't exist, we can proceed
+                // Need to reopen channel since passive declare closes it on 404
+                await channel.CloseAsync(cancellationToken);
+            }
+            
+            // Recreate channel after the passive declare check
+            await using var workChannel = await connectionManager.CreateChannelAsync(true, cancellationToken);
+
+            // Get initial message count for validation
+            var originalQueueInfo = await workChannel.QueueDeclarePassiveAsync(queueName, cancellationToken);
+            initialMessageCount = originalQueueInfo.MessageCount;
+            
+            logger.LogWarning(
+                "WARNING: Queue migration will cause a brief service interruption. " +
+                "Queue '{Queue}' has {MessageCount} messages. " +
+                "Any messages published during migration may be lost if producers are not paused.",
+                queueName, initialMessageCount);
+
+            logger.LogInformation("Creating backup queue '{BackupQueue}'", backupQueueName);
+            
+            // 1. Create Backup Queue (Quorum to be safe)
+            var backupArgs = new Dictionary<string, object?> { ["x-queue-type"] = "quorum" };
+            await workChannel.QueueDeclareAsync(
+                queue: backupQueueName, 
+                durable: true, 
+                exclusive: false, 
+                autoDelete: false, 
+                arguments: backupArgs, 
+                cancellationToken: cancellationToken);
+            backupQueueCreated = true;
+
+            // 2. Shovel messages: Original -> Backup (multiple passes to catch race conditions)
+            logger.LogInformation("Shoveling messages from '{Source}' to '{Dest}'", queueName, backupQueueName);
+            
+            // First pass
+            movedToBackup = await ShovelMessagesAsync(workChannel, queueName, backupQueueName, cancellationToken);
+            logger.LogInformation("First pass: Moved {MessageCount} messages to backup queue", movedToBackup);
+            
+            // Second pass to catch any messages that arrived during first pass
+            var additionalMessages = await ShovelMessagesAsync(workChannel, queueName, backupQueueName, cancellationToken);
+            if (additionalMessages > 0)
+            {
+                logger.LogWarning(
+                    "Caught {AdditionalCount} messages that arrived during migration. " +
+                    "Total messages in backup: {TotalCount}. " +
+                    "This indicates producers are still active during migration.",
+                    additionalMessages, movedToBackup + additionalMessages);
+                movedToBackup += additionalMessages;
+            }
+            
+            // Verify backup queue has expected message count
+            var backupQueueInfo = await workChannel.QueueDeclarePassiveAsync(backupQueueName, cancellationToken);
+            if (backupQueueInfo.MessageCount != movedToBackup)
+            {
+                throw new InvalidOperationException(
+                    $"Message count mismatch in backup queue. Expected {movedToBackup}, got {backupQueueInfo.MessageCount}. Aborting migration.");
+            }
+            
+            // 3. Delete Original Queue
+            logger.LogInformation("Deleting original queue '{Queue}'", queueName);
+            await workChannel.QueueDeleteAsync(queue: queueName, ifUnused: false, ifEmpty: false, cancellationToken: cancellationToken);
+            originalQueueDeleted = true;
+            
+            // 4. Create New Queue with Target Args
+            logger.LogInformation("Creating new queue '{Queue}' with target arguments", queueName);
+            await workChannel.QueueDeclareAsync(
+                queue: queueName, 
+                durable: true, 
+                exclusive: false, 
+                autoDelete: false, 
+                arguments: targetArgs, 
+                cancellationToken: cancellationToken);
+            newQueueCreated = true;
+                
+            // 5. Shovel messages: Backup -> New
+            logger.LogInformation("Shoveling messages from '{Source}' to '{Dest}'", backupQueueName, queueName);
+            var restoredCount = await ShovelMessagesAsync(workChannel, backupQueueName, queueName, cancellationToken);
+            
+            // Verify all messages were restored
+            if (restoredCount != movedToBackup)
+            {
+                logger.LogError(
+                    "Message count mismatch during restoration. Moved to backup: {BackupCount}, Restored: {RestoredCount}. " +
+                    "CRITICAL: Backup queue '{BackupQueue}' retained for manual inspection.",
+                    movedToBackup, restoredCount, backupQueueName);
+                throw new InvalidOperationException(
+                    $"Failed to restore all messages. Expected {movedToBackup}, restored {restoredCount}. " +
+                    $"Backup queue '{backupQueueName}' has been preserved for manual recovery.");
+            }
+            
+            // 6. Final verification before deleting backup
+            var finalBackupInfo = await workChannel.QueueDeclarePassiveAsync(backupQueueName, cancellationToken);
+            if (finalBackupInfo.MessageCount > 0)
+            {
+                logger.LogError(
+                    "Backup queue still contains {MessageCount} messages after restoration. " +
+                    "Backup queue '{BackupQueue}' retained for manual inspection.",
+                    finalBackupInfo.MessageCount, backupQueueName);
+                throw new InvalidOperationException(
+                    $"Backup queue still has {finalBackupInfo.MessageCount} messages. Manual verification required.");
+            }
+            
+            // 7. Delete Backup Queue (only if empty)
+            logger.LogInformation("Deleting backup queue '{BackupQueue}'", backupQueueName);
+            await workChannel.QueueDeleteAsync(queue: backupQueueName, ifUnused: false, ifEmpty: false, cancellationToken: cancellationToken);
+            
+            logger.LogInformation(
+                "Migration of queue '{Queue}' completed successfully. " +
+                "Migrated {MessageCount} messages (initial count was {InitialCount}).",
+                queueName, restoredCount, initialMessageCount);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, 
+                "Migration of queue '{Queue}' failed at stage: " +
+                "BackupCreated={BackupCreated}, OriginalDeleted={OriginalDeleted}, NewCreated={NewCreated}",
+                queueName, backupQueueCreated, originalQueueDeleted, newQueueCreated);
+            
+            // CRITICAL: Only cleanup backup queue if original queue still exists
+            // If original was deleted, backup contains all the data and MUST be preserved
+            if (backupQueueCreated && !originalQueueDeleted)
+            {
+                logger.LogInformation(
+                    "Original queue still exists. Safe to cleanup backup queue '{BackupQueue}'.",
+                    backupQueueName);
+                
+                try
+                {
+                    await using var cleanupChannel = await connectionManager.CreateChannelAsync(true, CancellationToken.None);
+                    var backupInfo = await cleanupChannel.QueueDeclarePassiveAsync(backupQueueName, CancellationToken.None);
+                    
+                    if (backupInfo.MessageCount == 0)
+                    {
+                        await cleanupChannel.QueueDeleteAsync(backupQueueName, ifUnused: false, ifEmpty: false, CancellationToken.None);
+                        logger.LogInformation("Cleaned up empty backup queue '{BackupQueue}'", backupQueueName);
+                    }
+                    else
+                    {
+                        logger.LogWarning(
+                            "Backup queue '{BackupQueue}' has {MessageCount} messages. NOT deleting for safety. Manual cleanup required.",
+                            backupQueueName, backupInfo.MessageCount);
+                    }
+                }
+                catch (Exception cleanupEx)
+                {
+                    logger.LogWarning(cleanupEx, 
+                        "Failed to cleanup backup queue '{BackupQueue}'. Manual cleanup may be required.", 
+                        backupQueueName);
+                }
+            }
+            else if (originalQueueDeleted)
+            {
+                logger.LogCritical(
+                    "CRITICAL: Original queue was deleted but migration failed. " +
+                    "Backup queue '{BackupQueue}' contains {MessageCount} messages and MUST NOT be deleted. " +
+                    "Manual recovery required: Rename backup queue to '{OriginalQueue}' or investigate new queue '{NewQueue}'.",
+                    backupQueueName, movedToBackup, queueName, newQueueCreated ? queueName : "not created");
+            }
+            
+            throw;
+        }
+    }
+    
+    private async Task<int> ShovelMessagesAsync(IChannel channel, string sourceQueue, string destQueue, CancellationToken cancellationToken)
+    {
+        int messageCount = 0;
+        int consecutiveEmptyChecks = 0;
+        const int MaxEmptyChecks = 3; // Check multiple times to ensure queue is truly empty
+        
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var result = await channel.BasicGetAsync(sourceQueue, false, cancellationToken);
+            if (result == null)
+            {
+                // Queue appears empty, but check a few times to ensure no race conditions
+                consecutiveEmptyChecks++;
+                if (consecutiveEmptyChecks >= MaxEmptyChecks)
+                {
+                    break; // Queue is truly empty
+                }
+                
+                // Small delay before rechecking (allows any in-flight messages to arrive)
+                await Task.Delay(100, cancellationToken);
+                continue;
+            }
+
+            // Reset empty check counter since we got a message
+            consecutiveEmptyChecks = 0;
+
+            try 
+            {
+                // Publish to destination
+                // Use default exchange with routing key = destQueue
+                var props = new BasicProperties(result.BasicProperties);
+                
+                await channel.BasicPublishAsync(
+                    exchange: "", 
+                    routingKey: destQueue, 
+                    mandatory: true, 
+                    basicProperties: props, 
+                    body: result.Body, 
+                    cancellationToken: cancellationToken);
+                
+                // Only ack after successful publish
+                await channel.BasicAckAsync(result.DeliveryTag, false, cancellationToken);
+                messageCount++;
+                
+                // Log progress periodically
+                if (messageCount % 100 == 0)
+                {
+                    logger.LogDebug("Shoveled {Count} messages from '{Source}' to '{Dest}'", 
+                        messageCount, sourceQueue, destQueue);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, 
+                    "Failed to shovel message #{MessageNum} from '{Source}' to '{Dest}'. " +
+                    "Message will be nacked and requeued. Migration aborted.",
+                    messageCount + 1, sourceQueue, destQueue);
+                
+                // Requeue the message so it's not lost
+                await channel.BasicNackAsync(result.DeliveryTag, false, requeue: true, cancellationToken);
+                throw;
+            }
+        }
+        
+        if (cancellationToken.IsCancellationRequested)
+        {
+            logger.LogWarning(
+                "Shovel operation cancelled after moving {MessageCount} messages from '{Source}' to '{Dest}'. " +
+                "Remaining messages are still in source queue.",
+                messageCount, sourceQueue, destQueue);
+        }
+        
+        return messageCount;
+    }
+
+    public async Task EnsureExchangeMigrationAsync(string exchangeName, string targetType, CancellationToken cancellationToken)
+    {
+         bool migrationNeeded = false;
+         try
+         {
+             await using var checkChannel = await connectionManager.CreateChannelAsync(true, cancellationToken);
+             await checkChannel.ExchangeDeclareAsync(
+                 exchange: exchangeName, 
+                 type: targetType, 
+                 durable: true, 
+                 autoDelete: false, 
+                 arguments: null, 
+                 cancellationToken: cancellationToken);
+         }
+         catch (OperationInterruptedException ex) when (ex.ShutdownReason?.ReplyCode == 406) 
+         {
+             logger.LogWarning("Exchange '{Exchange}' type mismatch. Recreating...", exchangeName);
+             migrationNeeded = true;
+         }
+
+         if (migrationNeeded)
+         {
+             await using var channel = await connectionManager.CreateChannelAsync(true, cancellationToken);
+             
+             logger.LogWarning(
+                 "WARNING: Deleting exchange '{Exchange}'. " +
+                 "This will remove ALL bindings to queues. " +
+                 "Any in-flight messages may be lost. " +
+                 "Ensure producers/consumers are paused before proceeding.",
+                 exchangeName);
+             
+             // Note: Unlike queues, exchanges don't store messages, so we can't preserve them.
+             // However, we lose bindings which must be recreated.
+             await channel.ExchangeDeleteAsync(exchange: exchangeName, ifUnused: false, cancellationToken: cancellationToken);
+             await channel.ExchangeDeclareAsync(
+                 exchange: exchangeName, 
+                 type: targetType, 
+                 durable: true, 
+                 autoDelete: false, 
+                 arguments: null, 
+                 cancellationToken: cancellationToken);
+             
+             logger.LogWarning(
+                 "Exchange '{Exchange}' migrated to type '{Type}'. " +
+                 "IMPORTANT: All previous bindings have been removed. " +
+                 "They will be recreated when topology manager runs, but messages may be lost in the interim.",
+                 exchangeName, targetType);
+         }
+    }
+}

--- a/tests/Ratatoskr.Tests/Integration/TopologyMigrationTests.cs
+++ b/tests/Ratatoskr.Tests/Integration/TopologyMigrationTests.cs
@@ -1,0 +1,455 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RabbitMQ.Client.Exceptions;
+using AwesomeAssertions;
+using RabbitMQ.Client;
+using Ratatoskr.Core;
+using Ratatoskr.RabbitMq.Config;
+using Ratatoskr.RabbitMq.Extensions;
+using Ratatoskr.Tests.Fixtures;
+
+namespace Ratatoskr.Tests.Integration;
+
+public class TopologyMigrationTests(
+    RabbitMqContainerFixture rabbitMq,
+    PostgresContainerFixture postgres) : RatatoskrIntegrationTest(rabbitMq, postgres)
+{
+    private string QueueName => $"mig-queue-{TestId}";
+    private string DlqName => $"mig-queue-{TestId}.dlq";
+    
+    /// <summary>
+    /// Helper to publish a CloudEvents-formatted message directly to RabbitMQ
+    /// </summary>
+    private async Task PublishCloudEventAsync(IChannel channel, string queueName, string messageBody, int index = 0)
+    {
+        var props = new BasicProperties
+        {
+            ContentType = "application/json",
+            MessageId = $"test-msg-{index}",
+            Timestamp = new AmqpTimestamp(DateTimeOffset.UtcNow.ToUnixTimeSeconds()),
+            Type = "test.event",
+            DeliveryMode = DeliveryModes.Persistent,
+            Headers = new Dictionary<string, object?>
+            {
+                ["cloudEvents_specversion"] = "1.0",
+                ["cloudEvents_id"] = $"test-msg-{index}",
+                ["cloudEvents_type"] = "test.event",
+                ["cloudEvents_source"] = "/test",
+                ["cloudEvents_time"] = DateTimeOffset.UtcNow.ToString("O"),
+                ["cloudEvents_datacontenttype"] = "application/json"
+            }
+        };
+        
+        var body = System.Text.Encoding.UTF8.GetBytes(messageBody);
+        await channel.BasicPublishAsync("", queueName, false, props, body);
+    }
+
+    [Test]
+    public async Task Migration_PreservesMessages_WhenConvertingToQuorum()
+    {
+        // Arrange: Create a "Legacy" Classic Queue with messages
+        var factory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString) };
+        await using var connection = await factory.CreateConnectionAsync();
+        await using var channel = await connection.CreateChannelAsync();
+
+        await channel.QueueDeclareAsync(
+            queue: QueueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: new Dictionary<string, object?> { ["x-queue-type"] = "classic" });
+
+        // Publish some CloudEvents-formatted messages
+        for (int i = 0; i < 10; i++)
+        {
+            var eventData = $"{{\"data\":\"msg-{i}\"}}";
+            await PublishCloudEventAsync(channel, QueueName, eventData, i);
+        }
+
+        // Act: Start Ratatoskr with Migration Enabled
+        await StartTestAsync(services =>
+        {
+            services.AddRatatoskr(bus => 
+            {
+                bus.UseRabbitMq(o => 
+                {
+                    o.ConnectionString = RabbitMqConnectionString;
+                    o.AutoMigrateTopology = true;
+                });
+                
+                // Define the desired topology (Quorum is default)
+                bus.AddCommandConsumeChannel(QueueName, c => c
+                    .WithRabbitMq(o => o
+                        .QueueName(QueueName)
+                        .WithQueueType(QueueType.Quorum))
+                    .Consumes<TestEvent>());
+                
+                // Add handler to consume and count messages
+                bus.AddHandler<TestEvent, CountingHandler>();
+            });
+            
+            services.AddSingleton(new CountingHandler());
+        });
+
+        // Assert
+        // We need to resolve the handler from the running application scope. 
+        // RatatoskrIntegrationTest helper 'StartTestAsync' creates a factory, but how do we access services?
+        // RatatoskrIntegrationTest stores _factory.
+        // We can use InScopeAsync logic or just expose factory services?
+        // Actually, we can just create a scope here.
+        
+        await InScopeAsync(ctx => 
+        {
+             var handler = ctx.ServiceProvider.GetRequiredService<CountingHandler>();
+             return handler.WaitForMessagesAsync(10);
+        });
+        
+        await InScopeAsync(ctx => 
+        {
+             var handler = ctx.ServiceProvider.GetRequiredService<CountingHandler>();
+             handler.ReceivedCount.Should().Be(10);
+        });
+
+        // Verify queue is Quorum
+        // Re-create connection/channel to avoid scope issues or reuse existing?
+        // Existing factory/connection variables are in scope range of this method?
+        // Wait, I declared them at top of method.
+        
+        // I will just use a new connection/channel to be clean and simple
+        var checkFactory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString) };
+        await using var checkConnection = await checkFactory.CreateConnectionAsync();
+        await using var checkChannel = await checkConnection.CreateChannelAsync();
+        
+        var act = async () => await checkChannel.QueueDeclareAsync(
+            queue: QueueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: new Dictionary<string, object?> { ["x-queue-type"] = "classic" });
+
+        await act.Should().ThrowAsync<OperationInterruptedException>()
+            .Where(e => e.ShutdownReason.ReplyCode == 406);
+    }
+
+    public class CountingHandler : IMessageHandler<TestEvent>
+    {
+        private int _count = 0;
+        private int _expectedCount;
+        private TaskCompletionSource _tcs = new();
+        private readonly System.Collections.Concurrent.ConcurrentBag<(TestEvent Message, MessageProperties Properties)> _receivedMessages = new();
+
+        public int ReceivedCount => _count;
+        public IReadOnlyCollection<(TestEvent Message, MessageProperties Properties)> ReceivedMessages => _receivedMessages;
+
+        public Task HandleAsync(TestEvent message, MessageProperties properties, CancellationToken cancellationToken)
+        {
+            _receivedMessages.Add((message, properties));
+            var newCount = Interlocked.Increment(ref _count);
+            
+            if (_expectedCount > 0 && newCount >= _expectedCount)
+            {
+                _tcs.TrySetResult();
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task WaitForMessagesAsync(int count, TimeSpan? timeout = null)
+        {
+            _expectedCount = count;
+            return _tcs.Task.WaitAsync(timeout ?? TimeSpan.FromSeconds(10));
+        }
+        
+        public void Reset(int expectedCount = 0)
+        {
+            _count = 0;
+            _expectedCount = expectedCount;
+            _receivedMessages.Clear();
+            _tcs = new TaskCompletionSource();
+        }
+    }
+    
+    [Test]
+    public async Task Migration_HandlesDlqConversion_FromTopicToFanout()
+    {
+        // Arrange: Create a "Legacy" DLQ Exchange (Topic) and Queue (Classic)
+        var factory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString) };
+        await using var connection = await factory.CreateConnectionAsync();
+        await using var channel = await connection.CreateChannelAsync();
+
+        // Topic Exchange
+        await channel.ExchangeDeclareAsync(
+            exchange: DlqName, 
+            type: ExchangeType.Topic, 
+            durable: true, 
+            autoDelete: false, 
+            arguments: null);
+        
+        // Classic Queue
+        await channel.QueueDeclareAsync(
+            queue: DlqName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: new Dictionary<string, object?> { ["x-queue-type"] = "classic" });
+        
+        // Bind
+        await channel.QueueBindAsync(DlqName, DlqName, "#");
+
+        // Publish a CloudEvents message to DLQ to ensure it survives
+        await PublishCloudEventAsync(channel, DlqName, "{\"data\":\"dlq-msg\"}", 0);
+
+        // Act
+        await StartTestAsync(services =>
+        {
+            services.AddRatatoskr(bus => 
+            {
+                bus.UseRabbitMq(o => 
+                {
+                    o.ConnectionString = RabbitMqConnectionString;
+                    o.AutoMigrateTopology = true;
+                });
+                
+                // This triggers provisioning, including DLQ migration
+                bus.AddCommandConsumeChannel(QueueName, c => c
+                    .WithRabbitMq(o => o
+                        .QueueName(QueueName)
+                        .RetryOptions(3, TimeSpan.FromMilliseconds(100))) // retry creates DLQ
+                    .Consumes<TestEvent>());
+            });
+        });
+
+        // Assert
+        // Verify DLQ Exchange is Fanout & Queue is Quorum
+        
+        var checkFactory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString) };
+        await using var checkConnection = await checkFactory.CreateConnectionAsync();
+        await using var checkChannel = await checkConnection.CreateChannelAsync();
+        
+        // Check Queue Type = Quorum (try declaring as classic -> should fail)
+        var act = async () => await checkChannel.QueueDeclareAsync(
+             queue: DlqName,
+             durable: true,
+             exclusive: false,
+             autoDelete: false,
+             arguments: new Dictionary<string, object?> { ["x-queue-type"] = "classic" });
+
+         await act.Should().ThrowAsync<OperationInterruptedException>()
+             .Where(e => e.ShutdownReason.ReplyCode == 406);
+             
+         // Check message exists - using a NEW channel because previous one is closed 406
+         await using var getChannel = await checkConnection.CreateChannelAsync();
+         var result = await getChannel.BasicGetAsync(DlqName, true);
+         
+         result.Should().NotBeNull();
+         // Verify it's a CloudEvents message
+         result!.BasicProperties.Headers.Should().ContainKey("cloudEvents_type");
+    }
+    
+    [Test]
+    public async Task Migration_SkipsMigration_WhenQueueAlreadyMatches()
+    {
+        // Arrange: Create queue with correct type already (Quorum)
+        var factory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString) };
+        await using var connection = await factory.CreateConnectionAsync();
+        await using var channel = await connection.CreateChannelAsync();
+        
+        await channel.QueueDeclareAsync(
+            queue: QueueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: new Dictionary<string, object?> { ["x-queue-type"] = "quorum" });
+        
+        // Act: Start Ratatoskr with same configuration
+        await StartTestAsync(services =>
+        {
+            services.AddRatatoskr(bus => 
+            {
+                bus.UseRabbitMq(o => 
+                {
+                    o.ConnectionString = RabbitMqConnectionString;
+                    o.AutoMigrateTopology = true;
+                });
+                
+                bus.AddCommandConsumeChannel(QueueName, c => c
+                    .WithRabbitMq(o => o
+                        .QueueName(QueueName)
+                        .WithQueueType(QueueType.Quorum))
+                    .Consumes<TestEvent>());
+            });
+        });
+        
+        // Assert: No backup queue should exist
+        var checkFactory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString) };
+        await using var checkConnection = await checkFactory.CreateConnectionAsync();
+        await using var checkChannel = await checkConnection.CreateChannelAsync();
+        
+        var act = async () => await checkChannel.QueueDeclarePassiveAsync($"{QueueName}.backup");
+        await act.Should().ThrowAsync<OperationInterruptedException>()
+            .Where(e => e.ShutdownReason.ReplyCode == 404); // Queue doesn't exist
+    }
+    
+    [Test]
+    public async Task Migration_PreservesMultipleMessages_WithUniqueContent()
+    {
+        // Arrange: Create classic queue with multiple messages with unique IDs
+        var factory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString) };
+        await using var connection = await factory.CreateConnectionAsync();
+        await using var channel = await connection.CreateChannelAsync();
+
+        await channel.QueueDeclareAsync(
+            queue: QueueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: new Dictionary<string, object?> { ["x-queue-type"] = "classic" });
+
+        // Publish CloudEvents messages with unique identifiers
+        for (int i = 0; i < 5; i++)
+        {
+            var eventData = $"{{\"data\":\"unique-message-{i}\"}}";
+            await PublishCloudEventAsync(channel, QueueName, eventData, i);
+        }
+
+        // Act: Migrate
+        await StartTestAsync(services =>
+        {
+            services.AddRatatoskr(bus => 
+            {
+                bus.UseRabbitMq(o => 
+                {
+                    o.ConnectionString = RabbitMqConnectionString;
+                    o.AutoMigrateTopology = true;
+                });
+                
+                bus.AddCommandConsumeChannel(QueueName, c => c
+                    .WithRabbitMq(o => o
+                        .QueueName(QueueName)
+                        .WithQueueType(QueueType.Quorum))
+                    .Consumes<TestEvent>());
+                
+                bus.AddHandler<TestEvent, CountingHandler>();
+            });
+            
+            services.AddSingleton(new CountingHandler());
+        });
+
+        await InScopeAsync(ctx => 
+        {
+            var handler = ctx.ServiceProvider.GetRequiredService<CountingHandler>();
+            return handler.WaitForMessagesAsync(5);
+        });
+
+        // Assert: Verify all messages received
+        await InScopeAsync(ctx => 
+        {
+            var handler = ctx.ServiceProvider.GetRequiredService<CountingHandler>();
+            handler.ReceivedMessages.Should().HaveCount(5);
+            handler.ReceivedCount.Should().Be(5);
+        });
+    }
+    
+    [Test]
+    public async Task Migration_HandlesEmptyQueue_Successfully()
+    {
+        // Arrange: Create empty classic queue
+        var factory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString) };
+        await using var connection = await factory.CreateConnectionAsync();
+        await using var channel = await connection.CreateChannelAsync();
+
+        await channel.QueueDeclareAsync(
+            queue: QueueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: new Dictionary<string, object?> { ["x-queue-type"] = "classic" });
+        
+        // Act: Migrate empty queue
+        await StartTestAsync(services =>
+        {
+            services.AddRatatoskr(bus => 
+            {
+                bus.UseRabbitMq(o => 
+                {
+                    o.ConnectionString = RabbitMqConnectionString;
+                    o.AutoMigrateTopology = true;
+                });
+                
+                bus.AddCommandConsumeChannel(QueueName, c => c
+                    .WithRabbitMq(o => o
+                        .QueueName(QueueName)
+                        .WithQueueType(QueueType.Quorum))
+                    .Consumes<TestEvent>());
+            });
+        });
+        
+        // Assert: Queue should be migrated to quorum
+        var checkFactory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString) };
+        await using var checkConnection = await checkFactory.CreateConnectionAsync();
+        await using var checkChannel = await checkConnection.CreateChannelAsync();
+        
+        // Try declaring as classic - should fail
+        var act = async () => await checkChannel.QueueDeclareAsync(
+            queue: QueueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: new Dictionary<string, object?> { ["x-queue-type"] = "classic" });
+
+        await act.Should().ThrowAsync<OperationInterruptedException>()
+            .Where(e => e.ShutdownReason.ReplyCode == 406);
+            
+        // Verify backup queue doesn't exist
+        await using var checkChannel2 = await checkConnection.CreateChannelAsync();
+        var actBackup = async () => await checkChannel2.QueueDeclarePassiveAsync($"{QueueName}.backup");
+        await actBackup.Should().ThrowAsync<OperationInterruptedException>()
+            .Where(e => e.ShutdownReason.ReplyCode == 404);
+    }
+    
+    [Test]
+    public async Task Migration_FailsGracefully_WhenBackupQueueAlreadyExists()
+    {
+        // Arrange: Create both the queue to migrate AND a backup queue
+        var factory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString) };
+        await using var connection = await factory.CreateConnectionAsync();
+        await using var channel = await connection.CreateChannelAsync();
+
+        await channel.QueueDeclareAsync(
+            queue: QueueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: new Dictionary<string, object?> { ["x-queue-type"] = "classic" });
+            
+        // Create backup queue that would block migration
+        var backupQueueName = $"{QueueName}.backup";
+        await channel.QueueDeclareAsync(
+            queue: backupQueueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: new Dictionary<string, object?> { ["x-queue-type"] = "quorum" });
+        
+        // Act & Assert: Should fail to start due to backup queue existing
+        var act = async () => await StartTestAsync(services =>
+        {
+            services.AddRatatoskr(bus => 
+            {
+                bus.UseRabbitMq(o => 
+                {
+                    o.ConnectionString = RabbitMqConnectionString;
+                    o.AutoMigrateTopology = true;
+                });
+                
+                bus.AddCommandConsumeChannel(QueueName, c => c
+                    .WithRabbitMq(o => o
+                        .QueueName(QueueName)
+                        .WithQueueType(QueueType.Quorum))
+                    .Consumes<TestEvent>());
+            });
+        });
+        
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .Where(e => e.Message.Contains("Backup queue") && e.Message.Contains("already exists"));
+    }
+}


### PR DESCRIPTION
Just some experiment, but I'm not sure if this could every be done safely in an generic & automated manner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic RabbitMQ topology migration capability that can be enabled via configuration to safely handle queue and exchange type conversions while preserving messages.

* **Documentation**
  * Added comprehensive documentation detailing the subscription architecture and messaging topology.

* **Tests**
  * Added integration tests validating topology migration behavior across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->