### PR TITLE
perf: cache GetProperties() deserialization in outbox/inbox entities (A-PERF-6)

### DIFF
--- a/docs/brainstorms/2026-03-31-project-evaluation.md
+++ b/docs/brainstorms/2026-03-31-project-evaluation.md
@@ -307,13 +307,14 @@ Performance-only concerns that do not affect correctness or functional requireme
 - Evidence: `src/Ratatoskr/AsyncApi/Extensions/AsyncApiEndpointExtensions.cs`
 - Source(s): Claude
 
-### A-PERF-6 · `GetProperties()` re-deserializes JSON on every call (no caching)
+### A-PERF-6 · ~~`GetProperties()` re-deserializes JSON on every call (no caching)~~ ✅ DONE
 
 - Verdict: `Valid`
 - Severity: Low (performance)
 - Detail: `OutboxMessageEntity.GetProperties()` and `InboxMessageEntity.GetProperties()` call `JsonSerializer.Deserialize` every time they are accessed. In the outbox processor the entity is accessed multiple times per message.
 - Evidence: `src/Ratatoskr.EfCore/Internal/OutboxMessageEntity.cs`, `src/Ratatoskr.EfCore/Internal/InboxMessageEntity.cs`
 - Source(s): Claude
+- **Resolution:** Added `_cachedProperties` field with `??=` pattern to cache deserialization result on first call in both entity classes.
 
 ### A-PERF-7 · `PublishDirectAsync` allocates a filtered array on every call
 

--- a/src/Ratatoskr.EfCore/Internal/InboxMessageEntity.cs
+++ b/src/Ratatoskr.EfCore/Internal/InboxMessageEntity.cs
@@ -22,8 +22,10 @@ internal class InboxMessageEntity
 
     public required DateTimeOffset ReceivedAt { get; init; }
 
+    private MessageProperties? _cachedProperties;
+
     public MessageProperties GetProperties() =>
-        JsonSerializer.Deserialize<MessageProperties>(SerializedProperties)
+        _cachedProperties ??= JsonSerializer.Deserialize<MessageProperties>(SerializedProperties)
         ?? throw new InvalidOperationException($"Could not deserialize MessageProperties for inbox message '{Id}'.");
 
     internal const int MaxIdLength = 200;

--- a/src/Ratatoskr.EfCore/Internal/OutboxMessageEntity.cs
+++ b/src/Ratatoskr.EfCore/Internal/OutboxMessageEntity.cs
@@ -54,8 +54,10 @@ internal class OutboxMessageEntity
     /// </summary>
     public uint Version { get; private set; }
 
-    public MessageProperties GetProperties() => 
-        JsonSerializer.Deserialize<MessageProperties>(SerializedProperties)
+    private MessageProperties? _cachedProperties;
+
+    public MessageProperties GetProperties() =>
+        _cachedProperties ??= JsonSerializer.Deserialize<MessageProperties>(SerializedProperties)
         ?? throw new OutboxMessageSerializationException("Could not deserialize the message properties.", SerializedProperties);
 
     private OutboxMessageEntity(){}


### PR DESCRIPTION
## Summary
- Added `_cachedProperties` field to `OutboxMessageEntity` and `InboxMessageEntity` to cache `GetProperties()` result
- Previously, each call to `GetProperties()` called `JsonSerializer.Deserialize` — in the outbox processor this happened multiple times per message
- Marked A-PERF-6 as resolved in the project evaluation document

## Test plan
- [x] Existing outbox processing tests pass (verified `OutboxBasicTests`)
- [x] Pure performance optimization — no behavioral change, regression covered by existing integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance when accessing message properties by implementing caching to eliminate redundant JSON deserialization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->