### PR TITLE
perf: replace per-publish LINQ allocation with FrozenDictionary lookup (A-PERF-7)

### DIFF
--- a/docs/brainstorms/2026-03-31-project-evaluation.md
+++ b/docs/brainstorms/2026-03-31-project-evaluation.md
@@ -321,13 +321,14 @@ Performance-only concerns that do not affect correctness or functional requireme
 - Source(s): Claude
 - **Resolution:** Added `_cachedProperties` field with `??=` pattern to cache deserialization result on first call in both entity classes.
 
-### A-PERF-7 · `PublishDirectAsync` allocates a filtered array on every call
+### A-PERF-7 · ~~`PublishDirectAsync` allocates a filtered array on every call~~ ✅ DONE
 
 - Verdict: `Valid`
 - Severity: Low (performance)
 - Detail: `_senders.Where(sender => ...).ToArray()` allocates on each publish invocation.
 - Evidence: `src/Ratatoskr/Ratatoskr.cs` (line 44)
 - Source(s): Claude
+- **Resolution:** Replaced LINQ `.Where().ToArray()` with a `FrozenDictionary<string, IMessageSender>` lookup built once at construction. Iterates transports directly with `TryGetValue` — zero per-call allocation.
 
 ---
 

--- a/src/Ratatoskr/Ratatoskr.cs
+++ b/src/Ratatoskr/Ratatoskr.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Ratatoskr.Core;
@@ -12,7 +13,7 @@ public class Ratatoskr(
     IEnumerable<IMessageActivityObserver> observers,
     ILogger<Ratatoskr> logger) : IRatatoskr
 {
-    private readonly IMessageSender[] _senders = senders.ToArray();
+    private readonly FrozenDictionary<string, IMessageSender> _senderMap = senders.ToFrozenDictionary(x => x.TransportName);
     private readonly IMessageActivityObserver[] _observers = observers.ToArray();
     public async Task PublishDirectAsync<TMessage>(
         TMessage message,
@@ -41,15 +42,14 @@ public class Ratatoskr(
             throw new InvalidOperationException($"No transport found for message '{typeof(TMessage)}'");
         }
 
-        var sendersToUse = _senders.Where(sender => props.Transports.Contains(sender.TransportName)).ToArray();
-        if (sendersToUse.Length == 0)
-        {
-            throw new InvalidOperationException($"No transport found for message '{typeof(TMessage)}'");
-        }
-
         List<Exception>? exceptions = null;
-        foreach (var sender in sendersToUse)
+        var matchedAny = false;
+        foreach (var transport in props.Transports)
         {
+            if (!_senderMap.TryGetValue(transport, out var sender))
+                continue;
+
+            matchedAny = true;
             Exception? sendException = null;
             try
             {
@@ -75,6 +75,11 @@ public class Ratatoskr(
                 Exception = sendException,
                 Timestamp = timeProvider.GetUtcNow(),
             }, logger);
+        }
+
+        if (!matchedAny)
+        {
+            throw new InvalidOperationException($"No transport found for message '{typeof(TMessage)}'");
         }
 
         if (exceptions is { Count: > 0 })


### PR DESCRIPTION
## Summary
- Replaced `_senders.Where(sender => ...).ToArray()` allocation on every `PublishDirectAsync` call with a `FrozenDictionary<string, IMessageSender>` built once at construction
- Iterates `props.Transports` directly with `TryGetValue` — zero per-call allocation
- `FrozenDictionary` optimizes the hash function at freeze time for read-heavy workloads

## Testing
- Existing outbox integration tests pass (they exercise the full publish path)
- No new tests needed — behavior is identical, only allocation characteristics change

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: internal optimization with identical behavior.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)