### PR TITLE
Warn on inbox messages without stable CloudEvents id

### DIFF
--- a/docs/cloudevents.md
+++ b/docs/cloudevents.md
@@ -131,6 +131,8 @@ When using the RabbitMQ transport, the `CloudEventsAmqpMapper` handles encoding 
 - Maps incoming AMQP headers back to `MessageProperties` on consume
 - Propagates W3C trace context through `traceparent` and `tracestate` headers
 
+If an incoming binary message has neither AMQP `message-id` nor a `cloudEvents_id` header, the mapper still assigns a synthetic id (a new GUID) so processing can continue, but it logs a **warning**: CloudEvents requires `id`, and inbox deduplication will not recognize duplicate deliveries of that message. Publishers should always set a stable event id.
+
 ## Trace Context Propagation
 
 Ratatoskr injects W3C trace context into CloudEvents attributes automatically:

--- a/src/Ratatoskr.RabbitMq/CloudEventsAmqpMapper.cs
+++ b/src/Ratatoskr.RabbitMq/CloudEventsAmqpMapper.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Ratatoskr.CloudEvents;
@@ -13,7 +14,8 @@ namespace Ratatoskr.RabbitMq;
 /// See: https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/amqp-protocol-binding.md
 /// </summary>
 public class CloudEventsAmqpMapper(
-    CloudEventsOptions options) : IRabbitMqEnvelopeMapper
+    CloudEventsOptions options,
+    ILogger<CloudEventsAmqpMapper> logger) : IRabbitMqEnvelopeMapper
 {
     public byte[] MapOutgoing(byte[] serializedData, MessageProperties props, BasicProperties outgoing)
     {
@@ -203,9 +205,16 @@ public class CloudEventsAmqpMapper(
         var incomingHeaders = incoming.BasicProperties.Headers ?? new Dictionary<string, object?>();
         
         // Prefer standard RabbitMQ properties over CloudEvents headers (Wolverine compatibility)
-        var id = incoming.BasicProperties.MessageId 
-                 ?? GetCloudEventHeader(incomingHeaders, CloudEventsAmqpConstants.IdHeader) 
-                 ?? Guid.NewGuid().ToString();
+        var id = incoming.BasicProperties.MessageId
+                 ?? GetCloudEventHeader(incomingHeaders, CloudEventsAmqpConstants.IdHeader);
+        if (id is null)
+        {
+            id = Guid.NewGuid().ToString();
+            logger.LogWarning(
+                "Incoming binary CloudEvent has no id (AMQP message-id and cloudEvents_id are missing). " +
+                "Generated id {GeneratedEventId}. Per CloudEvents spec, id is required; inbox deduplication will not treat replays of this message as duplicates.",
+                id);
+        }
         
         var type = incoming.BasicProperties.Type
                    ?? GetCloudEventHeader(incomingHeaders, CloudEventsAmqpConstants.TypeHeader)

--- a/src/Ratatoskr.RabbitMq/Ratatoskr.RabbitMq.csproj
+++ b/src/Ratatoskr.RabbitMq/Ratatoskr.RabbitMq.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Description>RabbitMQ transport for Ratatoskr CloudEventBus.</Description>
@@ -13,6 +13,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
       <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
       <PackageReference Include="MinVer">
         <PrivateAssets>all</PrivateAssets>

--- a/tests/Ratatoskr.Tests/RabbitMq/CloudEventsAmqpMapperIncomingTests.cs
+++ b/tests/Ratatoskr.Tests/RabbitMq/CloudEventsAmqpMapperIncomingTests.cs
@@ -1,6 +1,8 @@
 using System.Text;
 using System.Text.Json;
 using AwesomeAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Ratatoskr.CloudEvents;
@@ -11,7 +13,7 @@ namespace Ratatoskr.Tests.RabbitMq;
 
 public class CloudEventsAmqpMapperIncomingTests
 {
-    private readonly CloudEventsAmqpMapper _mapper = new(new CloudEventsOptions());
+    private readonly CloudEventsAmqpMapper _mapper = new(new CloudEventsOptions(), NullLogger<CloudEventsAmqpMapper>.Instance);
 
     [Test]
     public void MapBinaryModeIncoming_ShouldMapTraceContext()
@@ -160,6 +162,49 @@ public class CloudEventsAmqpMapperIncomingTests
         result.props.Should().NotBeNull();
         result.props.Id.Should().NotBeNullOrEmpty();
         result.body.Should().NotBeEmpty();
+    }
+
+    [Test]
+    public void MapIncoming_BinaryMode_MissingId_LogsWarning()
+    {
+        var warnings = new List<string>();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(new WarningCaptureLoggerProvider(warnings)));
+        var mapper = new CloudEventsAmqpMapper(new CloudEventsOptions(), factory.CreateLogger<CloudEventsAmqpMapper>());
+
+        var basicProperties = new BasicProperties { ContentType = "application/json" };
+        var body = Encoding.UTF8.GetBytes("{}");
+        var incoming = new BasicDeliverEventArgs("tag", 1, false, "ex", "rk", basicProperties, body);
+
+        var result = mapper.MapIncoming(incoming);
+
+        result.props.Id.Should().NotBeNullOrEmpty();
+        warnings.Should().ContainSingle();
+        warnings[0].Should().Contain("Incoming binary CloudEvent has no id");
+        warnings[0].Should().Contain("inbox deduplication");
+    }
+
+    private sealed class WarningCaptureLoggerProvider(List<string> sink) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new WarningCaptureLogger(sink);
+        public void Dispose() { }
+    }
+
+    private sealed class WarningCaptureLogger(List<string> sink) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                sink.Add(formatter(state, exception));
+            }
+        }
     }
 
     [Test]

--- a/tests/Ratatoskr.Tests/RabbitMq/CloudEventsAmqpMapperOutgoingTests.cs
+++ b/tests/Ratatoskr.Tests/RabbitMq/CloudEventsAmqpMapperOutgoingTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using RabbitMQ.Client;
 using Ratatoskr.CloudEvents;
 using Ratatoskr.Core;
@@ -10,7 +11,7 @@ namespace Ratatoskr.Tests.RabbitMq;
 
 public class CloudEventsAmqpMapperOutgoingTests
 {
-    private readonly CloudEventsAmqpMapper _mapper = new(new CloudEventsOptions());
+    private readonly CloudEventsAmqpMapper _mapper = new(new CloudEventsOptions(), NullLogger<CloudEventsAmqpMapper>.Instance);
 
     [Test]
     public void MapOutgoing_BinaryMode_SetsAllCloudEventHeaders()
@@ -72,7 +73,9 @@ public class CloudEventsAmqpMapperOutgoingTests
     public void MapOutgoing_StructuredMode_BodyContainsCloudEventEnvelope()
     {
         // Arrange
-        var structuredMapper = new CloudEventsAmqpMapper(new CloudEventsOptions { ContentMode = CloudEventsContentMode.Structured });
+        var structuredMapper = new CloudEventsAmqpMapper(
+            new CloudEventsOptions { ContentMode = CloudEventsContentMode.Structured },
+            NullLogger<CloudEventsAmqpMapper>.Instance);
         var now = DateTimeOffset.UtcNow;
         var props = new MessageProperties
         {
@@ -101,7 +104,9 @@ public class CloudEventsAmqpMapperOutgoingTests
     public void MapOutgoing_StructuredMode_ContentTypeIsCloudEventsJson()
     {
         // Arrange
-        var structuredMapper = new CloudEventsAmqpMapper(new CloudEventsOptions { ContentMode = CloudEventsContentMode.Structured });
+        var structuredMapper = new CloudEventsAmqpMapper(
+            new CloudEventsOptions { ContentMode = CloudEventsContentMode.Structured },
+            NullLogger<CloudEventsAmqpMapper>.Instance);
         var props = new MessageProperties
         {
             Id = "evt-123",
@@ -319,7 +324,9 @@ public class CloudEventsAmqpMapperOutgoingTests
     public void MapStructuredMode_ShouldNotIncludeRatatoskrHeaders()
     {
         // Arrange
-        var mapper = new CloudEventsAmqpMapper(new CloudEventsOptions { ContentMode = CloudEventsContentMode.Structured });
+        var mapper = new CloudEventsAmqpMapper(
+            new CloudEventsOptions { ContentMode = CloudEventsContentMode.Structured },
+            NullLogger<CloudEventsAmqpMapper>.Instance);
 
         var props = new MessageProperties
         {

--- a/tests/Ratatoskr.Tests/RabbitMq/CloudEventsAmqpMapperRoundTripTests.cs
+++ b/tests/Ratatoskr.Tests/RabbitMq/CloudEventsAmqpMapperRoundTripTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Ratatoskr.CloudEvents;
@@ -10,7 +11,7 @@ namespace Ratatoskr.Tests.RabbitMq;
 
 public class CloudEventsAmqpMapperRoundTripTests
 {
-    private readonly CloudEventsAmqpMapper _mapper = new(new CloudEventsOptions());
+    private readonly CloudEventsAmqpMapper _mapper = new(new CloudEventsOptions(), NullLogger<CloudEventsAmqpMapper>.Instance);
 
     [Test]
     public void MapOutgoing_BinaryMode_RoundTripsCorrectly()
@@ -50,7 +51,9 @@ public class CloudEventsAmqpMapperRoundTripTests
     public void MapOutgoing_StructuredMode_RoundTripsCorrectly()
     {
         // Arrange
-        var structuredMapper = new CloudEventsAmqpMapper(new CloudEventsOptions { ContentMode = CloudEventsContentMode.Structured });
+        var structuredMapper = new CloudEventsAmqpMapper(
+            new CloudEventsOptions { ContentMode = CloudEventsContentMode.Structured },
+            NullLogger<CloudEventsAmqpMapper>.Instance);
         var now = new DateTimeOffset(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
         var originalProps = new MessageProperties
         {
@@ -107,7 +110,9 @@ public class CloudEventsAmqpMapperRoundTripTests
     public void MapOutgoing_StructuredMode_DataSchema_RoundTripsCorrectly()
     {
         // Arrange
-        var structuredMapper = new CloudEventsAmqpMapper(new CloudEventsOptions { ContentMode = CloudEventsContentMode.Structured });
+        var structuredMapper = new CloudEventsAmqpMapper(
+            new CloudEventsOptions { ContentMode = CloudEventsContentMode.Structured },
+            NullLogger<CloudEventsAmqpMapper>.Instance);
         var originalProps = new MessageProperties
         {
             Id = "ds-struct-id",


### PR DESCRIPTION
## Summary
Fixes https://github.com/saithis/Ratatoskr/issues/53.

When consuming **binary** CloudEvents over RabbitMQ, if neither AMQP `message-id` nor the `cloudEvents_id` header is present, the mapper still generates a new GUID so the pipeline can run—but inbox deduplication cannot match replays. The mapper now logs a **warning** (with the generated id) so operators can fix publishers.

## Changes
- `CloudEventsAmqpMapper`: inject `ILogger<CloudEventsAmqpMapper>`, `LogWarning` on synthetic id path
- `Ratatoskr.RabbitMq.csproj`: explicit `Microsoft.Extensions.Logging.Abstractions` reference
- Tests: `NullLogger` for existing constructions; integration-style unit test asserts warning is emitted
- `docs/cloudevents.md`: document the warning behavior

## Testing
```bash
dotnet run --project tests/Ratatoskr.Tests -- --treenode-filter "/*/*/CloudEventsAmqpMapper*/*" --maximum-parallel-tests 10
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warning logging when processing incoming AMQP messages that lack CloudEvents event IDs, alerting users that inbox deduplication will not detect duplicate deliveries.

* **Documentation**
  * Updated guidance on AMQP mapping to explain ID requirements and recommend publishers always provide stable event identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->