### PR TITLE
feat: safeguard consume channels that forget UseInbox (fixes #55)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,7 @@ builder.Services.AddRatatoskr(bus =>
 | `.Consumes<T>(m => ...)` | Register a message type and handlers on a consume channel | [Messages & Handlers](messages-handlers.md) |
 | `.WithHandler<T>()` | Fire-and-forget handler (no persistence) | [Messages & Handlers](messages-handlers.md) |
 | `.WithHandler<T>("key")` | Inbox-managed handler with stable key | [Inbox](inbox.md) |
+| `.AllowConsumeWithoutInbox()` | Explicit opt-out from optional consume-channel inbox requirement policy | [Inbox](inbox.md) |
 
 ### Attributes
 
@@ -147,6 +148,7 @@ bus.AddEfCoreDurability<OrderDbContext>(d =>
 | `WithCleanupInterval(TimeSpan)` | `1h` | Cleanup run interval | [Inbox](inbox.md) |
 | `WithCleanupBatchSize(int)` | `10,000` | Cleanup batch size | [Inbox](inbox.md) |
 | `WithCleanupLockName(string)` | `"InboxCleanup_{DbContext}"` | Cleanup distributed lock name | [Operations](operations.md) |
+| `WithConsumeChannelInboxRequirement(ConsumeChannelInboxRequirement)` | `None` | Optional safeguard: warn/fail when consume channels omit `UseInbox()` | [Inbox](inbox.md) |
 | `WithoutBackgroundProcessing()` | — | Disable background service (testing) | [Testing](testing.md) |
 
 ## AsyncAPI

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -260,6 +260,7 @@ public class OrderDbContext(DbContextOptions<OrderDbContext> options)
 
 > [!NOTE]
 > The EF Core transport requires `UseInbox()` on all consume channels and a handler key on every handler. See [EF Core Transport](efcore-transport.md) for details.
+> If you use RabbitMQ and still want to enforce the same rule, configure `WithConsumeChannelInboxRequirement(ConsumeChannelInboxRequirement.Fail)` in [Inbox](inbox.md).
 
 ## EF Core Migrations
 

--- a/docs/inbox.md
+++ b/docs/inbox.md
@@ -45,6 +45,34 @@ The handler key (`"order-handler"`) is persisted in the database. It must be sta
 > [!WARNING]
 > On channels with `UseInbox()`, every handler **must** have a key. Registering a handler without a key throws `InvalidOperationException` at startup. Handler keys must be **globally unique** across all channels and DbContexts.
 
+### 4. Optional Safeguard: Require UseInbox on Consume Channels
+
+If your team standard is "all consume channels should use inbox," enable the policy in `UseInbox(...)`:
+
+```csharp
+bus.AddEfCoreDurability<OrderDbContext>(d => d.UseInbox(inbox =>
+{
+    inbox.WithConsumeChannelInboxRequirement(ConsumeChannelInboxRequirement.Fail);
+}));
+```
+
+Policy values:
+
+- `ConsumeChannelInboxRequirement.None` (default): no extra checks.
+- `ConsumeChannelInboxRequirement.Warn`: logs startup warnings for consume channels without `UseInbox<TDbContext>()`.
+- `ConsumeChannelInboxRequirement.Fail`: throws `InvalidOperationException` at startup.
+
+Per-channel opt-out is explicit:
+
+```csharp
+bus.AddEventConsumeChannel("legacy.fire-and-forget", c => c
+    .AllowConsumeWithoutInbox()
+    .Consumes<OrderPlaced>(m => m.WithHandler<LegacyHandler>()));
+```
+
+> [!NOTE]
+> This opt-out only affects the optional safeguard above. It does not bypass hard validation rules like EF Core transport requirements.
+
 ### Handler Key Renaming (Legacy Keys)
 
 When renaming a handler key, use legacy keys to drain in-flight messages under the old key:
@@ -180,6 +208,7 @@ bus.AddEfCoreDurability<OrderDbContext>(d => d.UseInbox(inbox =>
 | `WithCleanupInterval(TimeSpan)` | `1 hour` | How often the cleanup service runs |
 | `WithCleanupBatchSize(int)` | `10,000` | Messages deleted per cleanup batch |
 | `WithCleanupLockName(string)` | `"InboxCleanup_{DbContext}"` | Cleanup distributed lock name (auto-generated per DbContext) |
+| `WithConsumeChannelInboxRequirement(ConsumeChannelInboxRequirement)` | `None` | Optional safeguard for channels that forget `UseInbox()` |
 
 ## Data Retention
 

--- a/src/Ratatoskr.EfCore/ConsumeChannelInboxRequirement.cs
+++ b/src/Ratatoskr.EfCore/ConsumeChannelInboxRequirement.cs
@@ -1,0 +1,22 @@
+namespace Ratatoskr.EfCore;
+
+/// <summary>
+/// Controls whether consume channels are required to opt into <c>UseInbox&lt;TDbContext&gt;()</c>.
+/// </summary>
+public enum ConsumeChannelInboxRequirement
+{
+    /// <summary>
+    /// No additional validation. Channels without <c>UseInbox&lt;TDbContext&gt;()</c> are allowed.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Startup succeeds, but channels without <c>UseInbox&lt;TDbContext&gt;()</c> emit warnings.
+    /// </summary>
+    Warn = 1,
+
+    /// <summary>
+    /// Startup fails when a consume channel does not use <c>UseInbox&lt;TDbContext&gt;()</c>.
+    /// </summary>
+    Fail = 2
+}

--- a/src/Ratatoskr.EfCore/ConsumeChannelInboxRequirementOptOut.cs
+++ b/src/Ratatoskr.EfCore/ConsumeChannelInboxRequirementOptOut.cs
@@ -1,0 +1,7 @@
+namespace Ratatoskr.EfCore;
+
+/// <summary>
+/// Marker extension that opts a consume channel out of the optional
+/// consume-channel inbox requirement policy.
+/// </summary>
+public sealed class ConsumeChannelInboxRequirementOptOut;

--- a/src/Ratatoskr.EfCore/InboxBuilder.cs
+++ b/src/Ratatoskr.EfCore/InboxBuilder.cs
@@ -13,6 +13,15 @@ public class InboxBuilder<TDbContext> where TDbContext : DbContext
     internal InboxBuilder() { }
 
     /// <summary>
+    /// Requires consume channels to use inbox according to the selected policy.
+    /// </summary>
+    public InboxBuilder<TDbContext> WithConsumeChannelInboxRequirement(ConsumeChannelInboxRequirement requirement)
+    {
+        Options.ConsumeChannelInboxRequirement = requirement;
+        return this;
+    }
+
+    /// <summary>
     /// Sets the polling interval for checking the database for pending handler deliveries.
     /// </summary>
     public InboxBuilder<TDbContext> WithPollingInterval(TimeSpan interval)

--- a/src/Ratatoskr.EfCore/InboxConfigurationValidator.cs
+++ b/src/Ratatoskr.EfCore/InboxConfigurationValidator.cs
@@ -1,5 +1,6 @@
 using Ratatoskr.Config;
 using Ratatoskr.Core;
+using Ratatoskr.EfCore.Internal;
 
 namespace Ratatoskr.EfCore;
 
@@ -9,7 +10,10 @@ namespace Ratatoskr.EfCore;
 /// </summary>
 internal static class InboxConfigurationValidator
 {
-    public static void Validate(ChannelRegistry channelRegistry, ChannelHandlerRegistry handlerRegistry)
+    public static void Validate(
+        ChannelRegistry channelRegistry,
+        ChannelHandlerRegistry handlerRegistry,
+        ConsumeChannelInboxPolicyAggregator? policyAggregator = null)
     {
         foreach (var channel in channelRegistry.GetConsumeChannels())
         {
@@ -25,6 +29,9 @@ internal static class InboxConfigurationValidator
                     $"but does not have UseInbox<TDbContext>() configured. " +
                     $"Either add UseInbox<TDbContext>() to the channel or move fire-and-forget handlers to a separate channel without UseInbox.");
             }
+
+            if (inboxConfig == null && inboxHandlers.Count == 0)
+                ValidateChannelInboxRequirement(channel, policyAggregator);
 
             // UseInbox channel must not have fire-and-forget handlers
             if (inboxConfig != null)
@@ -53,6 +60,28 @@ internal static class InboxConfigurationValidator
                     $"Inbox handler for '{handler.HandlerType.Name}' has an empty stable key. " +
                     $"Provide a non-empty key via Consumes<TMsg>(m => m.WithHandler<THandler>(\"key\")).");
         }
+    }
+
+    private static void ValidateChannelInboxRequirement(
+        ChannelRegistration channel,
+        ConsumeChannelInboxPolicyAggregator? policyAggregator)
+    {
+        if (policyAggregator == null ||
+            policyAggregator.EffectiveRequirement == ConsumeChannelInboxRequirement.None)
+            return;
+
+        var isOptedOut = channel.GetExtension<ConsumeChannelInboxRequirementOptOut>() != null;
+        if (isOptedOut)
+            return;
+
+        var message =
+            $"Channel '{channel.ChannelName}' does not have UseInbox<TDbContext>() configured. " +
+            $"Either add UseInbox<TDbContext>() to the channel or explicitly opt out with AllowConsumeWithoutInbox().";
+
+        if (policyAggregator.EffectiveRequirement == ConsumeChannelInboxRequirement.Fail)
+            throw new InvalidOperationException(message);
+
+        policyAggregator.AddWarning(message);
     }
 
     private static IEnumerable<ChannelHandlerRegistration> GetAllHandlersForChannel(

--- a/src/Ratatoskr.EfCore/InboxOptions.cs
+++ b/src/Ratatoskr.EfCore/InboxOptions.cs
@@ -6,6 +6,12 @@ namespace Ratatoskr.EfCore;
 public class InboxOptions
 {
     /// <summary>
+    /// Controls whether consume channels are required to configure <c>UseInbox&lt;TDbContext&gt;()</c>.
+    /// Default: <see cref="ConsumeChannelInboxRequirement.None"/>.
+    /// </summary>
+    public ConsumeChannelInboxRequirement ConsumeChannelInboxRequirement { get; set; } = ConsumeChannelInboxRequirement.None;
+
+    /// <summary>
     /// How often to poll the database for pending handler deliveries.
     /// Default: 30 seconds.
     /// </summary>

--- a/src/Ratatoskr.EfCore/InboxPublicApiExtensions.cs
+++ b/src/Ratatoskr.EfCore/InboxPublicApiExtensions.cs
@@ -11,6 +11,16 @@ namespace Ratatoskr.EfCore;
 public static class InboxPublicApiExtensions
 {
     /// <summary>
+    /// Explicitly opts this consume channel out of the optional consume-channel inbox requirement policy.
+    /// This does not bypass transport-specific requirements (for example, EF Core transport still requires inbox).
+    /// </summary>
+    public static ConsumeChannelBuilder AllowConsumeWithoutInbox(this ConsumeChannelBuilder builder)
+    {
+        builder.Channel.SetExtension(new ConsumeChannelInboxRequirementOptOut());
+        return builder;
+    }
+
+    /// <summary>
     /// Enables the inbox pattern on this consume channel.
     /// All handlers registered with a stable key on this channel will be inbox-managed.
     /// Requires <c>AddEfCoreDurability&lt;TDbContext&gt;(d =&gt; d.UseInbox())</c> to be called on the bus builder.

--- a/src/Ratatoskr.EfCore/Internal/ConsumeChannelInboxPolicyAggregator.cs
+++ b/src/Ratatoskr.EfCore/Internal/ConsumeChannelInboxPolicyAggregator.cs
@@ -1,0 +1,40 @@
+namespace Ratatoskr.EfCore.Internal;
+
+internal sealed class ConsumeChannelInboxPolicyAggregator
+{
+    private readonly HashSet<string> _warnings = new(StringComparer.Ordinal);
+    private readonly object _sync = new();
+
+    public ConsumeChannelInboxRequirement EffectiveRequirement { get; private set; } = ConsumeChannelInboxRequirement.None;
+
+    public int WarningCount
+    {
+        get
+        {
+            lock (_sync)
+                return _warnings.Count;
+        }
+    }
+
+    public void MergeRequirement(ConsumeChannelInboxRequirement requirement)
+    {
+        if (requirement > EffectiveRequirement)
+            EffectiveRequirement = requirement;
+    }
+
+    public void AddWarning(string warning)
+    {
+        lock (_sync)
+            _warnings.Add(warning);
+    }
+
+    public string[] DrainWarnings()
+    {
+        lock (_sync)
+        {
+            var warnings = _warnings.ToArray();
+            _warnings.Clear();
+            return warnings;
+        }
+    }
+}

--- a/src/Ratatoskr.EfCore/Internal/ConsumeChannelInboxWarningHostedService.cs
+++ b/src/Ratatoskr.EfCore/Internal/ConsumeChannelInboxWarningHostedService.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Ratatoskr.EfCore.Internal;
+
+internal sealed class ConsumeChannelInboxWarningHostedService(
+    ConsumeChannelInboxPolicyAggregator policyAggregator,
+    ILogger<ConsumeChannelInboxWarningHostedService> logger) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        foreach (var warning in policyAggregator.DrainWarnings())
+            logger.LogWarning("{Warning}", warning);
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Ratatoskr.EfCore/PublicApiExtensions.cs
+++ b/src/Ratatoskr.EfCore/PublicApiExtensions.cs
@@ -77,12 +77,37 @@ public static class PublicApiExtensions
             ratatoskrBuilder.Services.AddSingleton<IEfCoreInboxAcceptor>(sp => sp.GetRequiredService<InboxAcceptor<TDbContext>>());
             ratatoskrBuilder.Services.AddSingleton<IMessageRouteInterceptor, InboxRouteInterceptor<TDbContext>>();
 
+            var policyAggregator = GetOrAddConsumeChannelInboxPolicyAggregator(ratatoskrBuilder.Services);
+            policyAggregator.MergeRequirement(inboxBuilder.Options.ConsumeChannelInboxRequirement);
+            if (policyAggregator.EffectiveRequirement == ConsumeChannelInboxRequirement.Warn)
+            {
+                ratatoskrBuilder.Services.TryAddEnumerable(
+                    ServiceDescriptor.Singleton<IHostedService, ConsumeChannelInboxWarningHostedService>());
+            }
+
             // EF Core transport services (registered once, idempotent)
             ratatoskrBuilder.Services.TryAddSingleton<EfCoreTelemetry>();
             ratatoskrBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IMessageSender, EfCoreMessageSender>());
 
-            ratatoskrBuilder.AddHandlerValidator(InboxConfigurationValidator.Validate);
+            ratatoskrBuilder.AddHandlerValidator((channelRegistry, handlerRegistry) =>
+                InboxConfigurationValidator.Validate(channelRegistry, handlerRegistry, policyAggregator));
             ratatoskrBuilder.AddValidator(EfCoreConfigurationValidator.Validate);
+        }
+
+        private static ConsumeChannelInboxPolicyAggregator GetOrAddConsumeChannelInboxPolicyAggregator(
+            IServiceCollection services)
+        {
+            var existing = services
+                .Where(d => d.ServiceType == typeof(ConsumeChannelInboxPolicyAggregator))
+                .Select(d => d.ImplementationInstance)
+                .OfType<ConsumeChannelInboxPolicyAggregator>()
+                .FirstOrDefault();
+            if (existing != null)
+                return existing;
+
+            var aggregator = new ConsumeChannelInboxPolicyAggregator();
+            services.AddSingleton(aggregator);
+            return aggregator;
         }
 
         private static void RegisterOutboxServices<TDbContext>(

--- a/tests/Ratatoskr.Tests/Core/InboxConfigurationValidatorTests.cs
+++ b/tests/Ratatoskr.Tests/Core/InboxConfigurationValidatorTests.cs
@@ -1,8 +1,10 @@
 using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Ratatoskr.Config;
 using Ratatoskr.Core;
 using Ratatoskr.EfCore;
+using Ratatoskr.EfCore.Internal;
 using Ratatoskr.Tests.Fixtures;
 using TUnit.Core;
 
@@ -187,6 +189,111 @@ public class InboxConfigurationValidatorTests
         // Act & Assert
         var act = () => InboxConfigurationValidator.Validate(channelRegistry, handlerRegistry);
         act.Should().NotThrow();
+    }
+
+    [Test]
+    public void Validate_ChannelWithoutUseInbox_RequirementFail_Throws()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var builder = new RatatoskrBuilder(services);
+        builder.AddEventConsumeChannel("test-channel", c => c
+            .Consumes<TestEvent>(m => m.WithHandler<TestEventHandler>()));
+
+        var channelRegistry = builder.ChannelRegistry;
+        var handlerRegistry = ChannelHandlerRegistry.Build(channelRegistry);
+        var policyAggregator = new ConsumeChannelInboxPolicyAggregator();
+        policyAggregator.MergeRequirement(ConsumeChannelInboxRequirement.Fail);
+
+        // Act & Assert
+        var act = () => InboxConfigurationValidator.Validate(channelRegistry, handlerRegistry, policyAggregator);
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*AllowConsumeWithoutInbox()*");
+    }
+
+    [Test]
+    public void Validate_ChannelWithoutUseInbox_RequirementFail_WithExplicitOptOut_DoesNotThrow()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var builder = new RatatoskrBuilder(services);
+        builder.AddEventConsumeChannel("test-channel", c => c
+            .AllowConsumeWithoutInbox()
+            .Consumes<TestEvent>(m => m.WithHandler<TestEventHandler>()));
+
+        var channelRegistry = builder.ChannelRegistry;
+        var handlerRegistry = ChannelHandlerRegistry.Build(channelRegistry);
+        var policyAggregator = new ConsumeChannelInboxPolicyAggregator();
+        policyAggregator.MergeRequirement(ConsumeChannelInboxRequirement.Fail);
+
+        // Act & Assert
+        var act = () => InboxConfigurationValidator.Validate(channelRegistry, handlerRegistry, policyAggregator);
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void Validate_ChannelWithoutUseInbox_RequirementWarn_AddsWarning()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var builder = new RatatoskrBuilder(services);
+        builder.AddEventConsumeChannel("test-channel", c => c
+            .Consumes<TestEvent>(m => m.WithHandler<TestEventHandler>()));
+
+        var channelRegistry = builder.ChannelRegistry;
+        var handlerRegistry = ChannelHandlerRegistry.Build(channelRegistry);
+        var policyAggregator = new ConsumeChannelInboxPolicyAggregator();
+        policyAggregator.MergeRequirement(ConsumeChannelInboxRequirement.Warn);
+
+        // Act
+        var act = () => InboxConfigurationValidator.Validate(channelRegistry, handlerRegistry, policyAggregator);
+
+        // Assert
+        act.Should().NotThrow();
+        policyAggregator.WarningCount.Should().Be(1);
+        policyAggregator.DrainWarnings().Should().ContainSingle()
+            .Which.Should().Contain("AllowConsumeWithoutInbox()");
+    }
+
+    [Test]
+    public void AddEfCoreDurability_WithConsumeChannelInboxRequirementFail_ThrowsAtStartup()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act & Assert
+        var act = () => services.AddRatatoskr(bus =>
+        {
+            bus.AddEventConsumeChannel("test-channel", c => c
+                .Consumes<TestEvent>(m => m.WithHandler<TestEventHandler>()));
+            bus.AddEfCoreDurability<TestDbContext>(d => d.UseInbox(inbox =>
+                inbox.WithConsumeChannelInboxRequirement(ConsumeChannelInboxRequirement.Fail)));
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*AllowConsumeWithoutInbox()*");
+    }
+
+    [Test]
+    public void AddEfCoreDurability_WithConsumeChannelInboxRequirementWarn_RegistersWarningHostedService()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        var act = () => services.AddRatatoskr(bus =>
+        {
+            bus.AddEventConsumeChannel("test-channel", c => c
+                .Consumes<TestEvent>(m => m.WithHandler<TestEventHandler>()));
+            bus.AddEfCoreDurability<TestDbContext>(d => d.UseInbox(inbox =>
+                inbox.WithConsumeChannelInboxRequirement(ConsumeChannelInboxRequirement.Warn)));
+        });
+
+        // Assert
+        act.Should().NotThrow();
+        services.Any(d => d.ServiceType == typeof(IHostedService) &&
+                          d.ImplementationType == typeof(ConsumeChannelInboxWarningHostedService))
+            .Should().BeTrue();
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `ConsumeChannelInboxRequirement` and `WithConsumeChannelInboxRequirement(...)` so inbox durability can optionally warn or fail startup when consume channels omit `UseInbox<TDbContext>()`.
- Add explicit per-channel opt-out via `AllowConsumeWithoutInbox()` and wire validation through a shared policy aggregator across multiple inbox DbContexts.
- Add tests covering `None`/`Warn`/`Fail` behavior and opt-out, plus update inbox/configuration/getting-started docs.

## Test plan
- [x] `dotnet run --project tests/Ratatoskr.Tests -- --treenode-filter "/*/*/InboxConfigurationValidatorTests/*" --maximum-parallel-tests 10`
- [x] `dotnet run --project tests/Ratatoskr.Tests -- --maximum-parallel-tests 10`

Closes #55

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable startup policy to enforce inbox usage on consume channels with three modes: no enforcement (default), startup warnings, or startup failure.
  * Added `WithConsumeChannelInboxRequirement()` configuration method to set enforcement behavior.
  * Added `AllowConsumeWithoutInbox()` method to opt individual channels out of enforcement.

* **Documentation**
  * Updated configuration reference and getting-started guides with new inbox enforcement options and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->