### PR TITLE
feat: add per-message serializer support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,19 +131,22 @@ sequenceDiagram
     participant App as Application
     participant R as IRatatoskr
     participant E as MessagePropertiesEnricher
+    participant SR as IMessageSerializerResolver
     participant S as IMessageSerializer
     participant Sender as IMessageSender[]
 
     App->>R: PublishDirectAsync<TMessage>(message)
     R->>E: Enrich(props)
     Note over E: Add ID, timestamp, trace context,<br/>resolve target transports
+    R->>SR: GetSerializer(typeof(TMessage))
+    SR-->>R: IMessageSerializer
     R->>S: Serialize(message) → byte[]
     loop For each matching transport
         R->>Sender: SendAsync(bytes, props)
     end
 ```
 
-The application calls `IRatatoskr.PublishDirectAsync<T>()`. Ratatoskr enriches the message properties (CloudEvents ID, timestamp, W3C trace context), serializes the message, then sends it to all `IMessageSender` implementations matching the configured transports.
+The application calls `IRatatoskr.PublishDirectAsync<T>()`. Ratatoskr enriches the message properties (CloudEvents ID, timestamp, W3C trace context), resolves the serializer for the message type, serializes the message, then sends it to all `IMessageSender` implementations matching the configured transports.
 
 ### Transactional Publishing (Outbox)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ builder.Services.AddRatatoskr(bus =>
 |--------|-------------|---------|
 | `.Produces<T>()` | Register a message type on a publish channel | [Channels & Routing](channels-routing.md) |
 | `.Consumes<T>(m => ...)` | Register a message type and handlers on a consume channel | [Messages & Handlers](messages-handlers.md) |
+| `.WithSerializer<TSerializer>()` | Use a serializer for a specific message type | [Messages & Handlers](messages-handlers.md) |
 | `.WithHandler<T>()` | Fire-and-forget handler (no persistence) | [Messages & Handlers](messages-handlers.md) |
 | `.WithHandler<T>("key")` | Inbox-managed handler with stable key | [Inbox](inbox.md) |
 

--- a/docs/messages-handlers.md
+++ b/docs/messages-handlers.md
@@ -130,14 +130,21 @@ For full control, implement `IMessageSerializer` directly:
 ```csharp
 public class CustomSerializer : IMessageSerializer
 {
-    public byte[] Serialize<T>(T message) where T : class
+    public string ContentType => "application/custom";
+
+    public byte[] Serialize(object message)
     {
         // Custom serialization logic
     }
 
-    public object Deserialize(byte[] data, Type type)
+    public object? Deserialize(byte[] data, Type type)
     {
         // Custom deserialization logic
+    }
+
+    public TMessage? Deserialize<TMessage>(byte[] body)
+    {
+        // Custom generic deserialization logic
     }
 }
 ```
@@ -147,6 +154,32 @@ Register it in the DI container **before** calling `AddRatatoskr`:
 ```csharp
 builder.Services.AddSingleton<IMessageSerializer, CustomSerializer>();
 ```
+
+### Per-Message Serializer
+
+You can override the serializer for a specific message type by configuring the message registration:
+
+```csharp
+builder.Services.AddSingleton<ProtobufOrderSerializer>();
+
+builder.Services.AddRatatoskr(bus =>
+{
+    bus.AddEventPublishChannel("orders.events", c => c
+        .Produces<OrderPlaced>(m => m.WithSerializer<ProtobufOrderSerializer>()));
+
+    bus.AddEventConsumeChannel("orders.events", c => c
+        .Consumes<OrderPlaced>(
+            h => h.WithHandler<OrderPlacedHandler>(),
+            m => m.WithSerializer<ProtobufOrderSerializer>()));
+});
+```
+
+Behavior and rules:
+
+- If a message has no `.WithSerializer<TSerializer>()`, Ratatoskr uses the global `IMessageSerializer`.
+- The configured serializer must be registered in DI.
+- A single message type can only use one serializer across channels.
+- `MessageProperties.ContentType` is set from the selected serializer for each message.
 
 ### Schema Evolution
 

--- a/src/Ratatoskr.EfCore/Internal/InboxMessageProcessor.cs
+++ b/src/Ratatoskr.EfCore/Internal/InboxMessageProcessor.cs
@@ -18,7 +18,7 @@ internal class InboxMessageProcessor<TDbContext>(
     TimeProvider timeProvider,
     InboxOptionsHolder<TDbContext> optionsHolder,
     IEnumerable<IMessageActivityObserver> observers,
-    IMessageSerializer messageSerializer,
+    IMessageSerializerResolver serializerResolver,
     ILogger<InboxMessageProcessor<TDbContext>> logger)
     where TDbContext : DbContext, IInboxDbContext
 {
@@ -153,7 +153,8 @@ internal class InboxMessageProcessor<TDbContext>(
             {
                 deliverActivity = telemetry.StartDeliverActivity(props, status.HandlerKey);
 
-                var message = messageSerializer.Deserialize(inboxMessage.Content, registration.MessageType)
+                var serializer = serializerResolver.GetSerializer(registration.MessageType);
+                var message = serializer.Deserialize(inboxMessage.Content, registration.MessageType)
                               ?? throw new InvalidOperationException(
                                   $"Deserialized message of type '{registration.MessageType.Name}' was null.");
 

--- a/src/Ratatoskr.EfCore/Internal/OutboxTriggerInterceptor.cs
+++ b/src/Ratatoskr.EfCore/Internal/OutboxTriggerInterceptor.cs
@@ -8,7 +8,7 @@ namespace Ratatoskr.EfCore.Internal;
 
 internal class OutboxTriggerInterceptor<TDbContext>(
     OutboxProcessor<TDbContext> outboxProcessor,
-    IMessageSerializer messageSerializer,
+    IMessageSerializerResolver serializerResolver,
     IMessagePropertiesEnricher enricher,
     ChannelRegistry channelRegistry,
     ChannelHandlerRegistry channelHandlerRegistry,
@@ -65,8 +65,9 @@ internal class OutboxTriggerInterceptor<TDbContext>(
         foreach (var item in stagedItems)
         {
             var enrichedProperties = enricher.Enrich(item.Message.GetType(), item.Properties);
-            var serializedMessage = messageSerializer.Serialize(item.Message);
-            enrichedProperties.ContentType = messageSerializer.ContentType;
+            var serializer = serializerResolver.GetSerializer(item.Message.GetType());
+            var serializedMessage = serializer.Serialize(item.Message);
+            enrichedProperties.ContentType = serializer.ContentType;
 
             if (_options.MaxMessageSize.HasValue && serializedMessage.Length > _options.MaxMessageSize.Value)
             {

--- a/src/Ratatoskr/Config/MessageBuilder.cs
+++ b/src/Ratatoskr/Config/MessageBuilder.cs
@@ -17,4 +17,10 @@ public class MessageBuilder(MessageRegistration message)
         message.DataSchema = dataSchema;
         return this;
     }
+
+    public MessageBuilder WithSerializer<TSerializer>() where TSerializer : class, IMessageSerializer
+    {
+        message.SerializerType = typeof(TSerializer);
+        return this;
+    }
 }

--- a/src/Ratatoskr/Core/IMessageSerializerResolver.cs
+++ b/src/Ratatoskr/Core/IMessageSerializerResolver.cs
@@ -1,0 +1,10 @@
+namespace Ratatoskr.Core;
+
+/// <summary>
+/// Resolves the serializer to use for a message type.
+/// Falls back to the global <see cref="IMessageSerializer"/> when no message-specific serializer is configured.
+/// </summary>
+public interface IMessageSerializerResolver
+{
+    IMessageSerializer GetSerializer(Type messageType);
+}

--- a/src/Ratatoskr/Core/MessageDispatcher.cs
+++ b/src/Ratatoskr/Core/MessageDispatcher.cs
@@ -11,7 +11,7 @@ namespace Ratatoskr.Core;
 public class MessageDispatcher(
     ChannelRegistry channelRegistry,
     ChannelHandlerRegistry channelHandlerRegistry,
-    IMessageSerializer deserializer,
+    IMessageSerializerResolver serializerResolver,
     HandlerInvoker handlerInvoker,
     TimeProvider timeProvider,
     IEnumerable<IMessageActivityObserver> observers,
@@ -71,7 +71,8 @@ public class MessageDispatcher(
         object? message;
         try
         {
-            message = deserializer.Deserialize(body, messageType);
+            var serializer = serializerResolver.GetSerializer(messageType);
+            message = serializer.Deserialize(body, messageType);
         }
         catch (Exception ex)
         {

--- a/src/Ratatoskr/Core/MessageRegistration.cs
+++ b/src/Ratatoskr/Core/MessageRegistration.cs
@@ -5,6 +5,7 @@ public class MessageRegistration(Type messageType, string messageTypeName)
     public Type MessageType { get; } = messageType;
     public string MessageTypeName { get; internal set; } = messageTypeName;
     public string? DataSchema { get; internal set; }
+    public Type? SerializerType { get; internal set; }
 
     private readonly Dictionary<Type, object> _extensions = new();
 

--- a/src/Ratatoskr/Core/MessageSerializerResolver.cs
+++ b/src/Ratatoskr/Core/MessageSerializerResolver.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ratatoskr.Core;
+
+internal sealed class MessageSerializerResolver(
+    ChannelRegistry channelRegistry,
+    IMessageSerializer defaultSerializer,
+    IEnumerable<IMessageSerializer> serializerCandidates,
+    IServiceProvider serviceProvider) : IMessageSerializerResolver
+{
+    private readonly Dictionary<Type, Type> _serializerTypesByMessageType = BuildSerializerMap(channelRegistry);
+    private readonly List<IMessageSerializer> _serializerCandidates = serializerCandidates.ToList();
+    private readonly Dictionary<Type, IMessageSerializer> _resolvedBySerializerType = new();
+    private readonly object _sync = new();
+
+    public IMessageSerializer GetSerializer(Type messageType)
+    {
+        if (!_serializerTypesByMessageType.TryGetValue(messageType, out var serializerType))
+            return defaultSerializer;
+
+        if (serializerType.IsInstanceOfType(defaultSerializer))
+            return defaultSerializer;
+
+        lock (_sync)
+        {
+            if (_resolvedBySerializerType.TryGetValue(serializerType, out var serializer))
+                return serializer;
+
+            serializer = ResolveConfiguredSerializer(serializerType);
+            _resolvedBySerializerType[serializerType] = serializer;
+            return serializer;
+        }
+    }
+
+    private IMessageSerializer ResolveConfiguredSerializer(Type serializerType)
+    {
+        var fromRegisteredSerializer = _serializerCandidates.FirstOrDefault(serializerType.IsInstanceOfType);
+        if (fromRegisteredSerializer != null)
+            return fromRegisteredSerializer;
+
+        var fromTypedResolution = serviceProvider.GetService(serializerType);
+        if (fromTypedResolution is IMessageSerializer typedSerializer)
+            return typedSerializer;
+
+        throw new InvalidOperationException(
+            $"Serializer '{serializerType.FullName}' is configured for one or more messages, but was not registered in DI. " +
+            $"Register it with services.AddSingleton<{serializerType.Name}>() or services.AddSingleton<IMessageSerializer, {serializerType.Name}>().");
+    }
+
+    private static Dictionary<Type, Type> BuildSerializerMap(ChannelRegistry channelRegistry)
+    {
+        var map = new Dictionary<Type, Type>();
+        foreach (var channel in channelRegistry.GetAllChannels())
+        {
+            foreach (var message in channel.Messages)
+            {
+                var serializerType = message.SerializerType;
+                if (serializerType == null)
+                    continue;
+
+                if (!map.TryGetValue(message.MessageType, out var existingSerializer))
+                {
+                    map[message.MessageType] = serializerType;
+                    continue;
+                }
+
+                if (existingSerializer != serializerType)
+                {
+                    throw new InvalidOperationException(
+                        $"Message type '{message.MessageType.FullName}' is configured with multiple serializers " +
+                        $"('{existingSerializer.FullName}' and '{serializerType.FullName}'). " +
+                        "Use a single serializer per message type.");
+                }
+            }
+        }
+
+        return map;
+    }
+}

--- a/src/Ratatoskr/Core/MessageSerializerResolver.cs
+++ b/src/Ratatoskr/Core/MessageSerializerResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Ratatoskr.Core;
@@ -8,33 +9,24 @@ internal sealed class MessageSerializerResolver(
     IEnumerable<IMessageSerializer> serializerCandidates,
     IServiceProvider serviceProvider) : IMessageSerializerResolver
 {
-    private readonly Dictionary<Type, Type> _serializerTypesByMessageType = BuildSerializerMap(channelRegistry);
-    private readonly List<IMessageSerializer> _serializerCandidates = serializerCandidates.ToList();
-    private readonly Dictionary<Type, IMessageSerializer> _resolvedBySerializerType = new();
-    private readonly object _sync = new();
+    private readonly FrozenDictionary<Type, IMessageSerializer> _serializerByMessageType =
+        BuildSerializerMap(channelRegistry, defaultSerializer, serializerCandidates, serviceProvider);
 
     public IMessageSerializer GetSerializer(Type messageType)
     {
-        if (!_serializerTypesByMessageType.TryGetValue(messageType, out var serializerType))
-            return defaultSerializer;
+        return _serializerByMessageType.GetValueOrDefault(messageType) ?? defaultSerializer;
+    }
 
+    private static IMessageSerializer ResolveConfiguredSerializer(
+        Type serializerType,
+        IMessageSerializer defaultSerializer,
+        IEnumerable<IMessageSerializer> serializerCandidates,
+        IServiceProvider serviceProvider)
+    {
         if (serializerType.IsInstanceOfType(defaultSerializer))
             return defaultSerializer;
 
-        lock (_sync)
-        {
-            if (_resolvedBySerializerType.TryGetValue(serializerType, out var serializer))
-                return serializer;
-
-            serializer = ResolveConfiguredSerializer(serializerType);
-            _resolvedBySerializerType[serializerType] = serializer;
-            return serializer;
-        }
-    }
-
-    private IMessageSerializer ResolveConfiguredSerializer(Type serializerType)
-    {
-        var fromRegisteredSerializer = _serializerCandidates.FirstOrDefault(serializerType.IsInstanceOfType);
+        var fromRegisteredSerializer = serializerCandidates.FirstOrDefault(serializerType.IsInstanceOfType);
         if (fromRegisteredSerializer != null)
             return fromRegisteredSerializer;
 
@@ -44,36 +36,67 @@ internal sealed class MessageSerializerResolver(
 
         throw new InvalidOperationException(
             $"Serializer '{serializerType.FullName}' is configured for one or more messages, but was not registered in DI. " +
-            $"Register it with services.AddSingleton<{serializerType.Name}>() or services.AddSingleton<IMessageSerializer, {serializerType.Name}>().");
+            $"Register it as its concrete type, for example services.AddSingleton<{serializerType.Name}>().");
     }
 
-    private static Dictionary<Type, Type> BuildSerializerMap(ChannelRegistry channelRegistry)
+    private static FrozenDictionary<Type, IMessageSerializer> BuildSerializerMap(
+        ChannelRegistry channelRegistry,
+        IMessageSerializer defaultSerializer,
+        IEnumerable<IMessageSerializer> serializerCandidates,
+        IServiceProvider serviceProvider)
     {
-        var map = new Dictionary<Type, Type>();
+        var serializerTypeMap = new Dictionary<Type, Type?>();
         foreach (var channel in channelRegistry.GetAllChannels())
         {
             foreach (var message in channel.Messages)
             {
                 var serializerType = message.SerializerType;
-                if (serializerType == null)
-                    continue;
-
-                if (!map.TryGetValue(message.MessageType, out var existingSerializer))
+                if (!serializerTypeMap.TryGetValue(message.MessageType, out var existingSerializerType))
                 {
-                    map[message.MessageType] = serializerType;
+                    serializerTypeMap[message.MessageType] = serializerType;
                     continue;
                 }
 
-                if (existingSerializer != serializerType)
+                if (existingSerializerType == serializerType)
+                    continue;
+
+                if (existingSerializerType == null || serializerType == null)
                 {
                     throw new InvalidOperationException(
-                        $"Message type '{message.MessageType.FullName}' is configured with multiple serializers " +
-                        $"('{existingSerializer.FullName}' and '{serializerType.FullName}'). " +
-                        "Use a single serializer per message type.");
+                        $"Message type '{message.MessageType.FullName}' mixes default and explicit serializer registrations. " +
+                        "Use a single serializer configuration per message type across all channels.");
                 }
+
+                throw new InvalidOperationException(
+                    $"Message type '{message.MessageType.FullName}' is configured with multiple serializers " +
+                    $"('{existingSerializerType.FullName}' and '{serializerType.FullName}'). " +
+                    "Use a single serializer per message type.");
             }
         }
 
-        return map;
+        var serializerByMessageType = new Dictionary<Type, IMessageSerializer>();
+        foreach (var (messageType, configuredSerializerType) in serializerTypeMap)
+        {
+            if (configuredSerializerType == null)
+                continue;
+
+            var serializer = ResolveConfiguredSerializer(
+                configuredSerializerType,
+                defaultSerializer,
+                serializerCandidates,
+                serviceProvider);
+            serializerByMessageType[messageType] = serializer;
+        }
+
+        try
+        {
+            return serializerByMessageType.ToFrozenDictionary();
+        }
+        catch (ArgumentException ex)
+        {
+            // Defensive guard to preserve a clear startup failure if map keys are duplicated.
+            throw new InvalidOperationException(
+                "Failed to build message serializer map due to duplicate message type registrations.", ex);
+        }
     }
 }

--- a/src/Ratatoskr/Ratatoskr.cs
+++ b/src/Ratatoskr/Ratatoskr.cs
@@ -6,7 +6,7 @@ using Ratatoskr.Core;
 namespace Ratatoskr;
 
 public class Ratatoskr(
-    IMessageSerializer serializer,
+    IMessageSerializerResolver serializerResolver,
     IEnumerable<IMessageSender> senders,
     IMessagePropertiesEnricher enricher,
     TimeProvider timeProvider,
@@ -34,6 +34,7 @@ public class Ratatoskr(
             activity.SetTag(MessagingSemanticConventions.MessageId, props.Id);
         }
 
+        var serializer = serializerResolver.GetSerializer(typeof(TMessage));
         var serializedMessage = serializer.Serialize(message);
         props.ContentType = serializer.ContentType;
 

--- a/src/Ratatoskr/ServiceCollectionExtensions.cs
+++ b/src/Ratatoskr/ServiceCollectionExtensions.cs
@@ -45,6 +45,7 @@ public static class ServiceCollectionExtensions
         // Register serializer (TryAdd so users can pre-register a custom IMessageSerializer)
         services.TryAddSingleton<IMessageSerializer>(
             new JsonMessageSerializer(builder.JsonSerializerOptions));
+        services.TryAddSingleton<IMessageSerializerResolver, MessageSerializerResolver>();
 
         services.TryAddSingleton<HandlerInvoker>();
         services.AddSingleton<IRatatoskr, Ratatoskr>();

--- a/tests/Ratatoskr.Tests/Core/MessageDispatcherTests.cs
+++ b/tests/Ratatoskr.Tests/Core/MessageDispatcherTests.cs
@@ -370,14 +370,18 @@ public class MessageDispatcherTests
 
         var channelHandlerRegistry = ChannelHandlerRegistry.Build(channelRegistry);
         var deserializer = new JsonMessageSerializer();
-
         var provider = services.BuildServiceProvider();
+        var serializerResolver = new MessageSerializerResolver(
+            channelRegistry,
+            deserializer,
+            [deserializer],
+            provider);
         var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
 
         return new MessageDispatcher(
             channelRegistry,
             channelHandlerRegistry,
-            deserializer,
+            serializerResolver,
             new HandlerInvoker(scopeFactory),
             TimeProvider.System,
             [],

--- a/tests/Ratatoskr.Tests/Core/RatatoskrBuilderTests.cs
+++ b/tests/Ratatoskr.Tests/Core/RatatoskrBuilderTests.cs
@@ -164,6 +164,49 @@ public class RatatoskrBuilderTests
         msg!.SerializerType.Should().Be(typeof(TestEventPipeMessageSerializer));
     }
 
+    [Test]
+    public void SerializerResolver_WithMixedDefaultAndExplicitSerializer_Throws()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<TestEventPipeMessageSerializer>();
+        services.AddRatatoskr(bus =>
+        {
+            bus.AddEventPublishChannel("pub-a", c => c.Produces<TestEvent>());
+            bus.AddEventConsumeChannel("con-a", c => c
+                .Consumes<TestEvent>(h => h.WithHandler<TestEventHandler>(),
+                    m => m.WithSerializer<TestEventPipeMessageSerializer>()));
+        });
+        using var provider = services.BuildServiceProvider();
+
+        // Act
+        var act = () => provider.GetRequiredService<IMessageSerializerResolver>();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*mixes default and explicit serializer registrations*");
+    }
+
+    [Test]
+    public void SerializerResolver_WithUnregisteredConcreteSerializer_ThrowsHelpfulMessage()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddRatatoskr(bus =>
+        {
+            bus.AddEventPublishChannel("pub-a", c => c
+                .Produces<TestEvent>(m => m.WithSerializer<TestEventPipeMessageSerializer>()));
+        });
+        using var provider = services.BuildServiceProvider();
+
+        // Act
+        var act = () => provider.GetRequiredService<IMessageSerializerResolver>();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Register it as its concrete type*");
+    }
+
     [RatatoskrMessage("event.with.schema", DataSchema = "https://schemas.example.com/event-with-schema/v1.json")]
     private record EventWithSchema;
 }

--- a/tests/Ratatoskr.Tests/Core/RatatoskrBuilderTests.cs
+++ b/tests/Ratatoskr.Tests/Core/RatatoskrBuilderTests.cs
@@ -147,6 +147,23 @@ public class RatatoskrBuilderTests
         msg!.DataSchema.Should().Be("https://override.example.com/v2.json");
     }
 
+    [Test]
+    public void Produces_WithSerializer_SetsSerializerOnRegistration()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var builder = new RatatoskrBuilder(services);
+
+        // Act
+        builder.AddEventPublishChannel("pub-channel", c => c
+            .Produces<TestEvent>(m => m.WithSerializer<TestEventPipeMessageSerializer>()));
+
+        // Assert
+        var channel = builder.ChannelRegistry.GetPublishChannel("pub-channel");
+        var msg = channel!.GetMessage(typeof(TestEvent));
+        msg!.SerializerType.Should().Be(typeof(TestEventPipeMessageSerializer));
+    }
+
     [RatatoskrMessage("event.with.schema", DataSchema = "https://schemas.example.com/event-with-schema/v1.json")]
     private record EventWithSchema;
 }

--- a/tests/Ratatoskr.Tests/Fixtures/TestEventPipeMessageSerializer.cs
+++ b/tests/Ratatoskr.Tests/Fixtures/TestEventPipeMessageSerializer.cs
@@ -1,0 +1,45 @@
+using System.Text;
+using Ratatoskr.Core;
+
+namespace Ratatoskr.Tests.Fixtures;
+
+public sealed class TestEventPipeMessageSerializer : IMessageSerializer
+{
+    public string ContentType => "application/x-ratatoskr-testevent-pipe";
+
+    public byte[] Serialize(object message)
+    {
+        if (message is not TestEvent testEvent)
+            throw new InvalidOperationException(
+                $"This serializer supports '{nameof(TestEvent)}' only.");
+
+        var encodedId = Convert.ToBase64String(Encoding.UTF8.GetBytes(testEvent.Id));
+        var encodedData = Convert.ToBase64String(Encoding.UTF8.GetBytes(testEvent.Data));
+        return Encoding.UTF8.GetBytes($"{encodedId}:{encodedData}");
+    }
+
+    public object? Deserialize(byte[] body, Type targetType)
+    {
+        if (targetType != typeof(TestEvent))
+            throw new InvalidOperationException(
+                $"This serializer supports '{nameof(TestEvent)}' only.");
+
+        return Deserialize<TestEvent>(body);
+    }
+
+    public TMessage? Deserialize<TMessage>(byte[] body)
+    {
+        if (typeof(TMessage) != typeof(TestEvent))
+            throw new InvalidOperationException(
+                $"This serializer supports '{nameof(TestEvent)}' only.");
+
+        var payload = Encoding.UTF8.GetString(body);
+        var parts = payload.Split(':', 2);
+        if (parts.Length != 2)
+            throw new InvalidOperationException("Invalid pipe serializer payload.");
+
+        var id = Encoding.UTF8.GetString(Convert.FromBase64String(parts[0]));
+        var data = Encoding.UTF8.GetString(Convert.FromBase64String(parts[1]));
+        return (TMessage?)(object)new TestEvent { Id = id, Data = data };
+    }
+}

--- a/tests/Ratatoskr.Tests/Fixtures/TestEventPipeMessageSerializer.cs
+++ b/tests/Ratatoskr.Tests/Fixtures/TestEventPipeMessageSerializer.cs
@@ -13,8 +13,8 @@ public sealed class TestEventPipeMessageSerializer : IMessageSerializer
             throw new InvalidOperationException(
                 $"This serializer supports '{nameof(TestEvent)}' only.");
 
-        var encodedId = Convert.ToBase64String(Encoding.UTF8.GetBytes(testEvent.Id));
-        var encodedData = Convert.ToBase64String(Encoding.UTF8.GetBytes(testEvent.Data));
+        var encodedId = Convert.ToBase64String(Encoding.UTF8.GetBytes(testEvent.Id ?? string.Empty));
+        var encodedData = Convert.ToBase64String(Encoding.UTF8.GetBytes(testEvent.Data ?? string.Empty));
         return Encoding.UTF8.GetBytes($"{encodedId}:{encodedData}");
     }
 

--- a/tests/Ratatoskr.Tests/Integration/ConsumeTests.cs
+++ b/tests/Ratatoskr.Tests/Integration/ConsumeTests.cs
@@ -121,6 +121,45 @@ public class ConsumeTests(
     }
 
     [Test]
+    public async Task Consume_WithPerMessageSerializer_UsesConfiguredSerializer()
+    {
+        // Arrange
+        var handler = new TestEventHandler();
+        await StartTestAsync(services =>
+        {
+            services.AddSingleton<TestEventHandler>(handler);
+            services.AddSingleton<TestEventPipeMessageSerializer>();
+            services.AddRatatoskr(bus =>
+            {
+                bus.UseRabbitMq(o => o.ConnectionString = new Uri(RabbitMqConnectionString));
+                bus.AddCommandConsumeChannel(QueueName, c =>
+                {
+                    c.WithRabbitMq(o => o.WithQueueName(QueueName).WithAutoAck(false).WithTransientQueue()
+                        .WithQueueType(QueueType.Classic));
+                    c.Consumes<TestEvent>(h => h.WithHandler<TestEventHandler>(),
+                        m => m.WithSerializer<TestEventPipeMessageSerializer>());
+                });
+            });
+        });
+
+        var serializer = new TestEventPipeMessageSerializer();
+        var serializedBody = serializer.Serialize(new TestEvent { Id = "pipe-1", Data = "pipe-data" });
+
+        // Act
+        await PublishBinaryCloudEventRawAsync(
+            QueueName,
+            serializedBody,
+            contentType: serializer.ContentType,
+            type: "test.event");
+
+        // Assert
+        await WaitForConditionAsync(() => handler.HandledMessages.Count > 0, TimeSpan.FromSeconds(2));
+        handler.HandledMessages.Should().HaveCount(1);
+        handler.HandledMessages[0].Id.Should().Be("pipe-1");
+        handler.HandledMessages[0].Data.Should().Be("pipe-data");
+    }
+
+    [Test]
     public async Task Consume_UnknownEventType_HandlerNotInvoked()
     {
         // Arrange
@@ -320,6 +359,27 @@ public class ConsumeTests(
             }
         };
         
+        await channel.BasicPublishAsync(exchange: "", routingKey: routingKey, mandatory: false, basicProperties: props, body: body);
+    }
+
+    private async Task PublishBinaryCloudEventRawAsync(string routingKey, byte[] body, string contentType, string type)
+    {
+        var factory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString) };
+        await using var connection = await factory.CreateConnectionAsync();
+        await using var channel = await connection.CreateChannelAsync();
+
+        var props = new BasicProperties
+        {
+            ContentType = contentType,
+            Headers = new Dictionary<string, object?>
+            {
+                ["cloudEvents_specversion"] = "1.0",
+                ["cloudEvents_type"] = type,
+                ["cloudEvents_source"] = "/test",
+                ["cloudEvents_id"] = Guid.NewGuid().ToString()
+            }
+        };
+
         await channel.BasicPublishAsync(exchange: "", routingKey: routingKey, mandatory: false, basicProperties: props, body: body);
     }
 

--- a/tests/Ratatoskr.Tests/Integration/ConsumeTests.cs
+++ b/tests/Ratatoskr.Tests/Integration/ConsumeTests.cs
@@ -340,26 +340,13 @@ public class ConsumeTests(
 
     private async Task PublishBinaryCloudEventAsync(string routingKey, TestEvent eventData)
     {
-        var factory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString) };
-        await using var connection = await factory.CreateConnectionAsync();
-        await using var channel = await connection.CreateChannelAsync();
-
         var json = System.Text.Json.JsonSerializer.Serialize(eventData);
         var body = Encoding.UTF8.GetBytes(json);
-
-        var props = new BasicProperties
-        {
-            ContentType = "application/json",
-            Headers = new Dictionary<string, object?>
-            {
-                ["cloudEvents_specversion"] = "1.0",
-                ["cloudEvents_type"] = "test.event",
-                ["cloudEvents_source"] = "/test",
-                ["cloudEvents_id"] = Guid.NewGuid().ToString()
-            }
-        };
-        
-        await channel.BasicPublishAsync(exchange: "", routingKey: routingKey, mandatory: false, basicProperties: props, body: body);
+        await PublishBinaryCloudEventRawAsync(
+            routingKey,
+            body,
+            contentType: "application/json",
+            type: "test.event");
     }
 
     private async Task PublishBinaryCloudEventRawAsync(string routingKey, byte[] body, string contentType, string type)
@@ -368,7 +355,14 @@ public class ConsumeTests(
         await using var connection = await factory.CreateConnectionAsync();
         await using var channel = await connection.CreateChannelAsync();
 
-        var props = new BasicProperties
+        var props = CreateBinaryCloudEventProperties(contentType, type);
+
+        await channel.BasicPublishAsync(exchange: "", routingKey: routingKey, mandatory: false, basicProperties: props, body: body);
+    }
+
+    private static BasicProperties CreateBinaryCloudEventProperties(string contentType, string type)
+    {
+        return new BasicProperties
         {
             ContentType = contentType,
             Headers = new Dictionary<string, object?>
@@ -379,8 +373,6 @@ public class ConsumeTests(
                 ["cloudEvents_id"] = Guid.NewGuid().ToString()
             }
         };
-
-        await channel.BasicPublishAsync(exchange: "", routingKey: routingKey, mandatory: false, basicProperties: props, body: body);
     }
 
     private async Task PublishStructuredCloudEventAsync(string routingKey, TestEvent eventData)

--- a/tests/Ratatoskr.Tests/Integration/Inbox/InboxBasicProcessingTests.cs
+++ b/tests/Ratatoskr.Tests/Integration/Inbox/InboxBasicProcessingTests.cs
@@ -13,6 +13,52 @@ public class InboxBasicProcessingTests(RabbitMqContainerFixture rabbitMq, Postgr
     : InboxTestBase(rabbitMq, postgres)
 {
     [Test]
+    public async Task Inbox_WithPerMessageSerializer_ProcessesMessageSuccessfully()
+    {
+        // Arrange
+        await StartTestAsync(services =>
+        {
+            services.AddSingleton<TestEventPipeMessageSerializer>();
+            services.AddRatatoskr(bus =>
+            {
+                bus.AddEventPublishChannel("inbox-events", c => c
+                    .WithEfCore()
+                    .Produces<TestEvent>(m => m.WithSerializer<TestEventPipeMessageSerializer>()));
+                bus.AddEventConsumeChannel("inbox-events", c => c
+                    .Consumes<TestEvent>(m => m.WithHandler<InboxHandlerA>("handler-a"),
+                        msg => msg.WithSerializer<TestEventPipeMessageSerializer>())
+                    .UseInbox<TestDbContext>());
+                bus.AddEfCoreDurability<TestDbContext>(d => d.UseInbox());
+            });
+
+            services.AddDbContext<TestDbContext>((sp, opts) =>
+                opts.UseNpgsql(PostgresConnectionString));
+        });
+
+        await InitializeDatabase();
+
+        // Act
+        await InScopeAsync(async ctx =>
+        {
+            var bus = ctx.ServiceProvider.GetRequiredService<IRatatoskr>();
+            await bus.PublishDirectAsync(
+                new TestEvent { Id = "business-pipe-inbox-1", Data = "pipe-inbox-data" },
+                new MessageProperties { Id = "pipe-inbox-1" });
+        });
+
+        // Assert
+        await WaitForConditionAsync(
+            async () => await InScopeAsync(async ctx =>
+            {
+                var db = ctx.ServiceProvider.GetRequiredService<TestDbContext>();
+                var status = await db.Set<InboxHandlerStatusEntity>()
+                    .SingleAsync(s => s.MessageId == "pipe-inbox-1");
+                return status.CompletedAt != null && !status.IsPoisoned;
+            }),
+            TimeSpan.FromSeconds(15));
+    }
+
+    [Test]
     public async Task Inbox_ReceivedAt_UsesInjectedTimeProvider()
     {
         var fixedInstant = new DateTimeOffset(2024, 3, 15, 14, 30, 0, TimeSpan.Zero);

--- a/tests/Ratatoskr.Tests/Integration/Outbox/OutboxProcessingTests.cs
+++ b/tests/Ratatoskr.Tests/Integration/Outbox/OutboxProcessingTests.cs
@@ -18,6 +18,53 @@ public class OutboxProcessingTests(RabbitMqContainerFixture rabbitMq, PostgresCo
     : OutboxTestBase(rabbitMq, postgres)
 {
     [Test]
+    public async Task Outbox_UsesPerMessageSerializer_ForStagedMessage()
+    {
+        // Arrange
+        await StartTestAsync(services =>
+        {
+            services.AddSingleton<TestEventPipeMessageSerializer>();
+            services.AddRatatoskr(bus =>
+            {
+                bus.AddEventPublishChannel(ExchangeName, c => c
+                    .WithEfCore()
+                    .Produces<TestEvent>(m => m.WithSerializer<TestEventPipeMessageSerializer>()));
+                bus.AddEfCoreDurability<TestDbContext>(d => d.UseOutbox(outbox => outbox.WithoutBackgroundProcessing()));
+            });
+
+            services.AddDbContext<TestDbContext>((sp, options) =>
+            {
+                options.UseNpgsql(PostgresConnectionString);
+                options.RegisterOutbox<TestDbContext>(sp);
+            });
+        });
+
+        await InitializeDatabase();
+
+        // Act
+        await InScopeAsync(async ctx =>
+        {
+            var dbContext = ctx.ServiceProvider.GetRequiredService<TestDbContext>();
+            dbContext.OutboxMessages.Add(new TestEvent { Id = "outbox-pipe-1", Data = "custom-body" });
+            await dbContext.SaveChangesAsync();
+        });
+
+        // Assert
+        await InScopeAsync(async ctx =>
+        {
+            var dbContext = ctx.ServiceProvider.GetRequiredService<TestDbContext>();
+            var entity = await dbContext.Set<OutboxMessageEntity>().SingleAsync();
+            var serializer = new TestEventPipeMessageSerializer();
+            var deserialized = serializer.Deserialize<TestEvent>(entity.Content);
+
+            deserialized.Should().NotBeNull();
+            deserialized!.Id.Should().Be("outbox-pipe-1");
+            deserialized.Data.Should().Be("custom-body");
+            entity.GetProperties().ContentType.Should().Be(serializer.ContentType);
+        });
+    }
+
+    [Test]
     public async Task ProcessAllAsync_SendsAllPendingMessages()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- add `MessageBuilder.WithSerializer<TSerializer>()` so message registrations can select serializers per message type
- add `IMessageSerializerResolver` and route publish/dispatch/outbox/inbox serialization through it with global fallback behavior
- add integration coverage for consume, outbox, and inbox per-message serializer behavior, plus docs updates for the new API

## Test plan
- [x] `dotnet run --project tests/Ratatoskr.Tests -- --treenode-filter "/*/*/RatatoskrBuilderTests/*" --maximum-parallel-tests 10`
- [x] `dotnet run --project tests/Ratatoskr.Tests -- --treenode-filter "/*/*/MessageDispatcherTests/*" --maximum-parallel-tests 10`
- [x] `dotnet run --project tests/Ratatoskr.Tests -- --treenode-filter "/*/*/ConsumeTests/*" --maximum-parallel-tests 10`
- [x] `dotnet run --project tests/Ratatoskr.Tests -- --treenode-filter "/*/*/OutboxProcessingTests/*" --maximum-parallel-tests 10`
- [x] `dotnet run --project tests/Ratatoskr.Tests -- --treenode-filter "/*/*/InboxBasicProcessingTests/*" --maximum-parallel-tests 10`
- [x] `dotnet run --project tests/Ratatoskr.Tests -- --maximum-parallel-tests 10`

Closes #51.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-message serializer support: assign a custom serializer to individual message types via fluent configuration; system falls back to the default when not set and records serializer content-type on messages.

* **Documentation**
  * Updated architecture, configuration, and message/handler docs to describe per-message serializer usage, resolution rules, and expected behaviors.

* **Tests**
  * Added unit and integration tests verifying per-message serializer configuration, resolution, and end-to-end processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->