### PR TITLE
ci: emit tunit test report

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,13 @@ jobs:
       with:
         fetch-depth: 0 # Still required for MinVer to calculate version numbers
 
+    - name: Expose GitHub Actions Runtime
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
+          core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -39,9 +39,42 @@ jobs:
 
     - name: Test
       # Runs all tests in the solution
-      run: dotnet test --no-build --configuration Release --verbosity normal
+      run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --report-trx
 
     - name: Verify Packaging
       # "Dry Run" - Ensures nuget packing works (e.g. checks for missing icons/licenses)
       # We do NOT push these anywhere, we just want to know if 'pack' fails.
       run: dotnet pack --no-build --configuration Release --output ./nupkgs
+
+    - name: Upload test results
+      if: always()  # Run even if tests fail
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: ./TestResults/*.trx
+
+    - name: Upload coverage
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage
+        path: ./TestResults/*.coverage
+
+  publish-results:
+    name: Publish Test Results
+    needs: test
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+    - name: Download all test results
+      uses: actions/download-artifact@v4
+      with:
+        pattern: test-results
+        path: ./TestResults
+
+    - name: Comment PR with results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      with:
+        files: ./TestResults/*.trx
+        comment_mode: always

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab if needed
   workflow_dispatch:
 
+permissions:
+  checks: write
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
         name: coverage
         path: ./TestResults/*.coverage
 
-  publish-results:
+  publish-test-results:
     name: Publish Test Results
     needs: build
     runs-on: ubuntu-latest
@@ -82,6 +82,20 @@ jobs:
       with:
         files: ./TestResults/*.trx
         comment_mode: always
+
+
+  publish-coverage-results:
+    name: Publish Coverage Results
+    needs: build
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+    - name: Download all test results
+      uses: actions/download-artifact@v4
+      with:
+        pattern: coverage
+        path: ./TestResults
 
     - name: Code Coverage Report
       uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      html-report-url: ${{ steps.upload-html.outputs.artifact-url }}
 
     steps:
     - name: Checkout Code
@@ -45,7 +43,7 @@ jobs:
 
     - name: Test
       # Runs all tests in the solution
-      run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --report-trx --github-reporter-style collapsible
+      run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --coverage-settings ./tests/coverage.config --report-trx --github-reporter-style collapsible
 
     - name: Verify Packaging
       # "Dry Run" - Ensures nuget packing works (e.g. checks for missing icons/licenses)
@@ -65,14 +63,6 @@ jobs:
       with:
         name: coverage
         path: ./TestResults/**/coverage.cobertura.xml
-
-    - name: Upload HTML report
-      id: upload-html
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: html-report
-        path: ./TestResults/**/*-report.html
 
   publish-results:
     name: Publish Results
@@ -114,7 +104,6 @@ jobs:
       env:
         TEST_RESULTS_JSON: ${{ steps.test-results.outputs.json }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        HTML_REPORT_URL: ${{ needs.build.outputs.html-report-url }}
       run: |
         echo "## Test Results & Code Coverage" > combined-pr-comment.md
         echo "" >> combined-pr-comment.md
@@ -122,20 +111,10 @@ jobs:
         # Test results summary
         if [ -n "$TEST_RESULTS_JSON" ]; then
           SUMMARY=$(echo "$TEST_RESULTS_JSON" | jq -r '.summary')
-          CHECK_URL=$(echo "$TEST_RESULTS_JSON" | jq -r '.check_url // empty')
 
           printf '%s\n' "$SUMMARY" >> combined-pr-comment.md
           echo "" >> combined-pr-comment.md
-
-          LINKS=""
-          if [ -n "$CHECK_URL" ]; then
-            LINKS="[Detailed Results](${CHECK_URL})"
-          fi
-          if [ -n "$HTML_REPORT_URL" ]; then
-            LINKS="${LINKS:+$LINKS | }[HTML Report](${HTML_REPORT_URL})"
-          fi
-          LINKS="${LINKS:+$LINKS | }[Workflow Run](${RUN_URL})"
-          echo "$LINKS" >> combined-pr-comment.md
+          echo "[HTML Report & Artifacts](${RUN_URL})" >> combined-pr-comment.md
         else
           echo "> :warning: No test results available. [View workflow run](${RUN_URL})" >> combined-pr-comment.md
         fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Test
       # Runs all tests in the solution
-      run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --report-trx --github-reporter-style collapsible
+      run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --coverage-output-format cobertura --report-trx --github-reporter-style collapsible
       env:
         TUNIT_GITHUB_REPORTER_STYLE: collapsible
 
@@ -64,7 +64,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage
-        path: ./TestResults/*.coverage
+        path: ./TestResults/**/*.cobertura.xml
 
   publish-test-results:
     name: Publish Test Results
@@ -76,13 +76,13 @@ jobs:
     - name: Download all test results
       uses: actions/download-artifact@v4
       with:
-        pattern: test-results
+        name: test-results
         path: ./TestResults
 
     - name: Comment PR with results
       uses: EnricoMi/publish-unit-test-result-action@v2
       with:
-        files: ./TestResults/*.trx
+        files: ./TestResults/**/*.trx
         comment_mode: always
 
 
@@ -93,19 +93,27 @@ jobs:
     if: always()
 
     steps:
-    - name: Download all test results
+    - name: Download coverage results
       uses: actions/download-artifact@v4
       with:
-        pattern: coverage
+        name: coverage
         path: ./TestResults
 
     - name: Code Coverage Report
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
-        filename: TestResults/*.coverage
+        filename: TestResults/**/*.cobertura.xml
         badge: true
         format: markdown
         hide_branch_rate: false
         hide_complexity: true
         indicators: true
         output: both
+
+    - name: Add Coverage PR Comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      if: github.event_name == 'pull_request'
+      with:
+        header: code-coverage
+        recreate: true
+        path: code-coverage-results.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      html-report-url: ${{ steps.upload-html.outputs.artifact-url }}
 
     steps:
     - name: Checkout Code
@@ -43,7 +45,7 @@ jobs:
 
     - name: Test
       # Runs all tests in the solution
-      run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --coverage-output-format cobertura --report-trx --github-reporter-style collapsible
+      run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --report-trx --github-reporter-style collapsible
 
     - name: Verify Packaging
       # "Dry Run" - Ensures nuget packing works (e.g. checks for missing icons/licenses)
@@ -62,9 +64,10 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage
-        path: ./TestResults/**/*.cobertura.xml
+        path: ./TestResults/**/coverage.cobertura.xml
 
     - name: Upload HTML report
+      id: upload-html
       if: always()
       uses: actions/upload-artifact@v4
       with:
@@ -98,24 +101,20 @@ jobs:
         files: ./TestResults/**/*.trx
         comment_mode: "off"
 
-    - name: Code Coverage Report
-      id: coverage
-      uses: irongut/CodeCoverageSummary@v1.3.0
+    - name: Generate Coverage Report
+      uses: danielpalme/ReportGenerator-GitHub-Action@5
       continue-on-error: true
       with:
-        filename: CoverageResults/**/*.cobertura.xml
-        badge: true
-        format: markdown
-        hide_branch_rate: false
-        hide_complexity: true
-        indicators: true
-        output: both
+        reports: CoverageResults/**/coverage.cobertura.xml
+        targetdir: CoverageReport
+        reporttypes: MarkdownSummaryGithub
 
     - name: Build Combined PR Comment
       if: always() && github.event_name == 'pull_request'
       env:
         TEST_RESULTS_JSON: ${{ steps.test-results.outputs.json }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        HTML_REPORT_URL: ${{ needs.build.outputs.html-report-url }}
       run: |
         echo "## Test Results & Code Coverage" > combined-pr-comment.md
         echo "" >> combined-pr-comment.md
@@ -132,21 +131,24 @@ jobs:
           if [ -n "$CHECK_URL" ]; then
             LINKS="[Detailed Results](${CHECK_URL})"
           fi
-          LINKS="${LINKS:+$LINKS | }[HTML Report & Artifacts](${RUN_URL}#artifacts)"
+          if [ -n "$HTML_REPORT_URL" ]; then
+            LINKS="${LINKS:+$LINKS | }[HTML Report](${HTML_REPORT_URL})"
+          fi
+          LINKS="${LINKS:+$LINKS | }[Workflow Run](${RUN_URL})"
           echo "$LINKS" >> combined-pr-comment.md
         else
           echo "> :warning: No test results available. [View workflow run](${RUN_URL})" >> combined-pr-comment.md
         fi
 
         # Code coverage (collapsible)
-        if [ -f code-coverage-results.md ]; then
+        if [ -f CoverageReport/SummaryGithub.md ]; then
           echo "" >> combined-pr-comment.md
           echo "---" >> combined-pr-comment.md
           echo "" >> combined-pr-comment.md
           echo "<details>" >> combined-pr-comment.md
           echo "<summary><strong>Code Coverage</strong></summary>" >> combined-pr-comment.md
           echo "" >> combined-pr-comment.md
-          cat code-coverage-results.md >> combined-pr-comment.md
+          cat CoverageReport/SummaryGithub.md >> combined-pr-comment.md
           echo "" >> combined-pr-comment.md
           echo "</details>" >> combined-pr-comment.md
         fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  checks: write
-  pull-requests: write
+  contents: read
 
 jobs:
   build:
@@ -41,6 +40,9 @@ jobs:
       # builds with the Release configuration for better optimization
       run: dotnet build --no-restore --configuration Release
 
+    - name: Install dotnet-coverage
+      run: dotnet tool install --global dotnet-coverage
+
     - name: Test
       # Runs all tests in the solution
       run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --coverage-settings ./tests/coverage.config --report-trx --github-reporter-style collapsible
@@ -69,6 +71,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: always()
+    permissions:
+      checks: write
+      pull-requests: write
 
     steps:
     - name: Download test results

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,8 +44,6 @@ jobs:
     - name: Test
       # Runs all tests in the solution
       run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --coverage-output-format cobertura --report-trx --github-reporter-style collapsible
-      env:
-        TUNIT_GITHUB_REPORTER_STYLE: collapsible
 
     - name: Verify Packaging
       # "Dry Run" - Ensures nuget packing works (e.g. checks for missing icons/licenses)
@@ -53,11 +51,11 @@ jobs:
       run: dotnet pack --no-build --configuration Release --output ./nupkgs
 
     - name: Upload test results
-      if: always()  # Run even if tests fail
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: test-results
-        path: ./TestResults/*.trx
+        path: ./TestResults/**/*.trx
 
     - name: Upload coverage
       if: always()
@@ -66,43 +64,46 @@ jobs:
         name: coverage
         path: ./TestResults/**/*.cobertura.xml
 
-  publish-test-results:
-    name: Publish Test Results
+    - name: Upload HTML report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-report
+        path: ./TestResults/**/*-report.html
+
+  publish-results:
+    name: Publish Results
     needs: build
     runs-on: ubuntu-latest
     if: always()
 
     steps:
-    - name: Download all test results
+    - name: Download test results
       uses: actions/download-artifact@v4
       with:
         name: test-results
         path: ./TestResults
 
-    - name: Comment PR with results
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      with:
-        files: ./TestResults/**/*.trx
-        comment_mode: always
-
-
-  publish-coverage-results:
-    name: Publish Coverage Results
-    needs: build
-    runs-on: ubuntu-latest
-    if: always()
-
-    steps:
-    - name: Download coverage results
+    - name: Download coverage
       uses: actions/download-artifact@v4
       with:
         name: coverage
-        path: ./TestResults
+        path: ./CoverageResults
+      continue-on-error: true
+
+    - name: Publish Test Results
+      id: test-results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      with:
+        files: ./TestResults/**/*.trx
+        comment_mode: "off"
 
     - name: Code Coverage Report
+      id: coverage
       uses: irongut/CodeCoverageSummary@v1.3.0
+      continue-on-error: true
       with:
-        filename: TestResults/**/*.cobertura.xml
+        filename: CoverageResults/**/*.cobertura.xml
         badge: true
         format: markdown
         hide_branch_rate: false
@@ -110,10 +111,49 @@ jobs:
         indicators: true
         output: both
 
-    - name: Add Coverage PR Comment
+    - name: Build Combined PR Comment
+      if: always() && github.event_name == 'pull_request'
+      env:
+        TEST_RESULTS_JSON: ${{ steps.test-results.outputs.json }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        echo "## Test Results & Code Coverage" > combined-pr-comment.md
+        echo "" >> combined-pr-comment.md
+
+        # Test results summary
+        if [ -n "$TEST_RESULTS_JSON" ]; then
+          SUMMARY=$(echo "$TEST_RESULTS_JSON" | jq -r '.summary')
+          CHECK_URL=$(echo "$TEST_RESULTS_JSON" | jq -r '.check_url // empty')
+
+          printf '%s\n' "$SUMMARY" >> combined-pr-comment.md
+          echo "" >> combined-pr-comment.md
+
+          LINKS=""
+          if [ -n "$CHECK_URL" ]; then
+            LINKS="[Detailed Results](${CHECK_URL})"
+          fi
+          LINKS="${LINKS:+$LINKS | }[HTML Report & Artifacts](${RUN_URL}#artifacts)"
+          echo "$LINKS" >> combined-pr-comment.md
+        else
+          echo "> :warning: No test results available. [View workflow run](${RUN_URL})" >> combined-pr-comment.md
+        fi
+
+        # Code coverage (collapsible)
+        if [ -f code-coverage-results.md ]; then
+          echo "" >> combined-pr-comment.md
+          echo "---" >> combined-pr-comment.md
+          echo "" >> combined-pr-comment.md
+          echo "<details>" >> combined-pr-comment.md
+          echo "<summary><strong>Code Coverage</strong></summary>" >> combined-pr-comment.md
+          echo "" >> combined-pr-comment.md
+          cat code-coverage-results.md >> combined-pr-comment.md
+          echo "" >> combined-pr-comment.md
+          echo "</details>" >> combined-pr-comment.md
+        fi
+
+    - name: Add PR Comment
       uses: marocchino/sticky-pull-request-comment@v2
-      if: github.event_name == 'pull_request'
+      if: always() && github.event_name == 'pull_request'
       with:
-        header: code-coverage
-        recreate: true
-        path: code-coverage-results.md
+        header: test-results
+        path: combined-pr-comment.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,9 @@ jobs:
 
     - name: Test
       # Runs all tests in the solution
-      run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --report-trx
+      run: dotnet test --no-build --configuration Release --results-directory ./TestResults -- --coverage --report-trx --github-reporter-style collapsible
+      env:
+        TUNIT_GITHUB_REPORTER_STYLE: collapsible
 
     - name: Verify Packaging
       # "Dry Run" - Ensures nuget packing works (e.g. checks for missing icons/licenses)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -66,7 +66,7 @@ jobs:
 
   publish-results:
     name: Publish Test Results
-    needs: test
+    needs: build
     runs-on: ubuntu-latest
     if: always()
 
@@ -82,3 +82,14 @@ jobs:
       with:
         files: ./TestResults/*.trx
         comment_mode: always
+
+    - name: Code Coverage Report
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: TestResults/coverage.cobertura.xml
+        badge: true
+        format: markdown
+        hide_branch_rate: false
+        hide_complexity: true
+        indicators: true
+        output: both

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
     - name: Code Coverage Report
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
-        filename: TestResults/coverage.cobertura.xml
+        filename: TestResults/*.coverage
         badge: true
         format: markdown
         hide_branch_rate: false

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   

--- a/tests/coverage.config
+++ b/tests/coverage.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <CodeCoverage>
+    <ModulePaths>
+      <Include>
+        <ModulePath>.*Ratatoskr.*\.dll$</ModulePath>
+      </Include>
+      <Exclude>
+        <ModulePath>.*Tests?\.dll$</ModulePath>
+        <ModulePath>.*TestHost\.dll$</ModulePath>
+      </Exclude>
+    </ModulePaths>
+  </CodeCoverage>
+</Configuration>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to restrict top-level permissions, allow workflows to export runtime/result variables, and always upload test and coverage artifacts for downstream processing.
* **Tests**
  * Test runs now emit TRX and Cobertura coverage outputs; a follow-up job collects artifacts, publishes unit test results, generates a Markdown coverage summary, and creates/updates a sticky PR comment with test and coverage details (PRs only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->