### PR TITLE
fix: OTEL traces aren't linked correctly

### DIFF
--- a/docs/cloudevents.md
+++ b/docs/cloudevents.md
@@ -132,7 +132,11 @@ If an incoming binary message has neither AMQP `message-id` nor a `cloudEvents_i
 
 ## Trace Context Propagation
 
-W3C trace context (`traceparent`/`tracestate`) is propagated through messages automatically. On publish, Ratatoskr creates tracing activities and the trace context flows into the AMQP message headers. On consume, the trace context is extracted and used to continue the distributed trace.
+W3C trace context (`traceparent`/`tracestate`) is propagated through messages automatically.
+
+For RabbitMQ and CloudEvents, Ratatoskr stores trace context in CloudEvents fields (`cloudEvents_traceparent` / `cloudEvents_tracestate` in binary mode, and CloudEvents extension attributes in structured mode). On consume, Ratatoskr prefers this CloudEvents trace context and falls back to bare AMQP `traceparent`/`tracestate` headers when needed.
+
+This keeps Ratatoskr publish and consume spans in the same distributed trace even when broker/client instrumentation adds transport-level spans with separate context handling.
 
 This enables end-to-end tracing across services without any manual instrumentation. See [Observability](observability.md) for the complete tracing setup.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -23,8 +23,9 @@ Ratatoskr creates `Activity` spans at key pipeline stages:
 
 Trace context is automatically propagated through messages:
 
-1. On publish, `traceparent` and `tracestate` are injected into the message as W3C trace context headers
-2. On consume, the trace context is extracted and used to create a child activity, continuing the distributed trace across services
+1. On publish, Ratatoskr stores `traceparent` and `tracestate` in CloudEvents trace fields
+2. On consume, Ratatoskr first restores trace context from those CloudEvents fields and falls back to bare transport `traceparent`/`tracestate` headers when needed
+3. The restored context is used to create a child activity, continuing the distributed trace across services
 
 This means your existing APM tools (Jaeger, Zipkin, Azure Monitor, Datadog, etc.) will show end-to-end traces spanning publish → transport → consume → handle.
 

--- a/src/Ratatoskr.RabbitMq/CloudEventsAmqpMapper.cs
+++ b/src/Ratatoskr.RabbitMq/CloudEventsAmqpMapper.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
@@ -105,6 +106,13 @@ public class CloudEventsAmqpMapper(
         {
             SetCloudEventHeader(outgoing.Headers, ext.Key, ext.Value?.ToString());
         }
+
+        // Preserve Ratatoskr's own trace context in CloudEvents-prefixed headers.
+        // RabbitMQ.Client may add/override bare traceparent/tracestate headers with
+        // transport-level span context; the CloudEvents headers keep logical message
+        // continuity for Ratatoskr spans across producer/consumer boundaries.
+        SetCloudEventHeader(outgoing.Headers, CloudEventsAmqpConstants.TraceParentHeader, props.TraceParent);
+        SetCloudEventHeader(outgoing.Headers, CloudEventsAmqpConstants.TraceStateHeader, props.TraceState);
         
         // Add custom headers (non-CloudEvents)
         foreach (var header in props.Headers)
@@ -137,6 +145,22 @@ public class CloudEventsAmqpMapper(
             data = Convert.ToBase64String(serializedData);
         }
         
+        var extensions = props.CloudEventExtensions.Count > 0
+            ? new Dictionary<string, object>(props.CloudEventExtensions)
+            : null;
+
+        if (!string.IsNullOrWhiteSpace(props.TraceParent))
+        {
+            extensions ??= new Dictionary<string, object>();
+            extensions[CloudEventsAmqpConstants.TraceParentHeader] = props.TraceParent;
+        }
+
+        if (!string.IsNullOrWhiteSpace(props.TraceState))
+        {
+            extensions ??= new Dictionary<string, object>();
+            extensions[CloudEventsAmqpConstants.TraceStateHeader] = props.TraceState;
+        }
+
         var cloudEvent = new CloudEventEnvelope
         {
             Id = props.Id!,
@@ -147,7 +171,7 @@ public class CloudEventsAmqpMapper(
             DataSchema = props.DataSchema,
             Subject = props.Subject,
             Data = data,
-            Extensions = props.CloudEventExtensions.Count > 0 ? props.CloudEventExtensions : null
+            Extensions = extensions
         };
         
         var envelopeBytes = JsonSerializer.SerializeToUtf8Bytes(cloudEvent);
@@ -224,17 +248,7 @@ public class CloudEventsAmqpMapper(
         var subject = GetCloudEventHeader(incomingHeaders, CloudEventsAmqpConstants.SubjectHeader);
         var dataSchema = GetCloudEventHeader(incomingHeaders, CloudEventsAmqpConstants.DataSchemaHeader);
 
-        // Extract trace context from the standard W3C traceparent AMQP header.
-        // RabbitMQ.Client 7.x sets this during BasicPublishAsync with a child span of our
-        // send activity. Fall back to cloudEvents_traceparent for backward compatibility
-        // with messages published by older versions that set the CloudEvents header manually.
-        var traceParent = incomingHeaders.TryGetValue("traceparent", out var tp)
-            ? ConvertToString(tp)
-            : GetCloudEventHeader(incomingHeaders, CloudEventsAmqpConstants.TraceParentHeader);
-
-        var traceState = incomingHeaders.TryGetValue("tracestate", out var ts)
-            ? ConvertToString(ts)
-            : GetCloudEventHeader(incomingHeaders, CloudEventsAmqpConstants.TraceStateHeader);
+        var (traceParent, traceState) = ResolveTraceContextFromBinaryHeaders(incomingHeaders);
         
         // Build headers dictionary (include all headers)
         var headers = new Dictionary<string, string>();
@@ -280,22 +294,16 @@ public class CloudEventsAmqpMapper(
             dataBytes = Array.Empty<byte>();
         }
         
-        // Extract trace context from the standard W3C traceparent AMQP header (set by
-        // RabbitMQ.Client 7.x during BasicPublishAsync). Fall back to CloudEvent extensions
-        // for backward compatibility with messages that embedded trace context in the envelope.
         var incomingHeaders = incoming.BasicProperties.Headers ?? new Dictionary<string, object?>();
-        var traceParent = incomingHeaders.TryGetValue("traceparent", out var tp)
-            ? ConvertToString(tp) : null;
-        if (traceParent == null)
-        {
-            cloudEvent.TryGetExtension<string>(CloudEventsAmqpConstants.TraceParentHeader, out traceParent);
-        }
-        var traceState = incomingHeaders.TryGetValue("tracestate", out var ts)
-            ? ConvertToString(ts) : null;
-        if (traceState == null)
-        {
-            cloudEvent.TryGetExtension<string>(CloudEventsAmqpConstants.TraceStateHeader, out traceState);
-        }
+        cloudEvent.TryGetExtension<string>(CloudEventsAmqpConstants.TraceParentHeader, out var envelopeTraceParent);
+        cloudEvent.TryGetExtension<string>(CloudEventsAmqpConstants.TraceStateHeader, out var envelopeTraceState);
+        var (traceParent, traceState) = ResolveTraceContextWithFallback(
+            envelopeTraceParent,
+            envelopeTraceState,
+            GetHeaderValue(incomingHeaders, CloudEventsAmqpConstants.TraceParentHeader),
+            GetHeaderValue(incomingHeaders, CloudEventsAmqpConstants.TraceStateHeader),
+            GetCloudEventHeader(incomingHeaders, CloudEventsAmqpConstants.TraceParentHeader),
+            GetCloudEventHeader(incomingHeaders, CloudEventsAmqpConstants.TraceStateHeader));
 
         var props = new MessageProperties
         {
@@ -364,6 +372,51 @@ public class CloudEventsAmqpMapper(
         
         return null;
     }
+
+    private static (string? traceParent, string? traceState) ResolveTraceContextFromBinaryHeaders(IDictionary<string, object?> headers)
+    {
+        return ResolveTraceContextWithFallback(
+            GetCloudEventHeader(headers, CloudEventsAmqpConstants.TraceParentHeader),
+            GetCloudEventHeader(headers, CloudEventsAmqpConstants.TraceStateHeader),
+            GetHeaderValue(headers, CloudEventsAmqpConstants.TraceParentHeader),
+            GetHeaderValue(headers, CloudEventsAmqpConstants.TraceStateHeader));
+    }
+
+    private static (string? traceParent, string? traceState) ResolveTraceContextWithFallback(
+        string? preferredTraceParent,
+        string? preferredTraceState,
+        string? fallbackTraceParent,
+        string? fallbackTraceState,
+        string? additionalTraceParent = null,
+        string? additionalTraceState = null)
+    {
+        if (TryParseTraceContext(preferredTraceParent, preferredTraceState))
+        {
+            return (preferredTraceParent, preferredTraceState);
+        }
+
+        if (TryParseTraceContext(fallbackTraceParent, fallbackTraceState))
+        {
+            return (fallbackTraceParent, fallbackTraceState);
+        }
+
+        if (TryParseTraceContext(additionalTraceParent, additionalTraceState))
+        {
+            return (additionalTraceParent, additionalTraceState);
+        }
+
+        return (preferredTraceParent ?? fallbackTraceParent ?? additionalTraceParent, preferredTraceState ?? fallbackTraceState ?? additionalTraceState);
+    }
+
+    private static bool TryParseTraceContext(string? traceParent, string? traceState)
+    {
+        return !string.IsNullOrWhiteSpace(traceParent) && ActivityContext.TryParse(traceParent, traceState, out _);
+    }
+
+    private static string? GetHeaderValue(IDictionary<string, object?> headers, string key)
+    {
+        return headers.TryGetValue(key, out var value) ? ConvertToString(value) : null;
+    }
     
     /// <summary>
     /// Converts header values to strings (handles byte arrays from RabbitMQ).
@@ -375,6 +428,8 @@ public class CloudEventsAmqpMapper(
             null => "",
             string str => str,
             byte[] bytes => Encoding.UTF8.GetString(bytes),
+            ReadOnlyMemory<byte> readOnlyMemory => Encoding.UTF8.GetString(readOnlyMemory.Span),
+            Memory<byte> memory => Encoding.UTF8.GetString(memory.Span),
             _ => value.ToString() ?? ""
         };
     }

--- a/tests/Ratatoskr.Tests/RabbitMq/CloudEventsAmqpMapperIncomingTests.cs
+++ b/tests/Ratatoskr.Tests/RabbitMq/CloudEventsAmqpMapperIncomingTests.cs
@@ -75,10 +75,9 @@ public class CloudEventsAmqpMapperIncomingTests
     }
 
     [Test]
-    public void MapBinaryModeIncoming_ShouldPreferBareTraceparent_WhenBothHeadersExist()
+    public void MapBinaryModeIncoming_ShouldPreferCloudEventsTraceparent_WhenBothHeadersExist()
     {
-        // When both headers exist, the standard W3C traceparent takes priority
-        // (set by RabbitMQ.Client 7.x during BasicPublishAsync).
+        // Ratatoskr's CloudEvents trace context takes priority when present.
         var headers = new Dictionary<string, object?>
         {
             { "traceparent", "00-rmq-client-trace-01" },
@@ -99,7 +98,62 @@ public class CloudEventsAmqpMapperIncomingTests
 
         var result = _mapper.MapIncoming(incoming);
 
-        result.props.TraceParent.Should().Be("00-rmq-client-trace-01");
+        result.props.TraceParent.Should().Be("00-ratatoskr-send-trace-01");
+    }
+
+    [Test]
+    public void MapBinaryModeIncoming_ShouldDecodeReadOnlyMemoryTraceHeaderValues()
+    {
+        var headers = new Dictionary<string, object?>
+        {
+            { "traceparent", new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")) },
+            { "tracestate", new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("vendor=memory")) },
+            { "cloudEvents_id", "123" },
+            { "cloudEvents_source", "/unit-test" },
+            { "cloudEvents_type", "test.event" }
+        };
+
+        var basicProperties = new BasicProperties
+        {
+            Headers = headers,
+            ContentType = "application/json"
+        };
+
+        var body = Encoding.UTF8.GetBytes("{}");
+        var incoming = new BasicDeliverEventArgs("tag", 1, false, "ex", "rk", basicProperties, body);
+
+        var result = _mapper.MapIncoming(incoming);
+
+        result.props.TraceParent.Should().Be("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
+        result.props.TraceState.Should().Be("vendor=memory");
+    }
+
+    [Test]
+    public void MapBinaryModeIncoming_ShouldFallbackToBareTraceparent_WhenCloudEventsTraceparentIsInvalid()
+    {
+        var headers = new Dictionary<string, object?>
+        {
+            { "cloudEvents_traceparent", "invalid-traceparent" },
+            { "traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" },
+            { "tracestate", "vendor=bare" },
+            { "cloudEvents_id", "123" },
+            { "cloudEvents_source", "/unit-test" },
+            { "cloudEvents_type", "test.event" }
+        };
+
+        var basicProperties = new BasicProperties
+        {
+            Headers = headers,
+            ContentType = "application/json"
+        };
+
+        var body = Encoding.UTF8.GetBytes("{}");
+        var incoming = new BasicDeliverEventArgs("tag", 1, false, "ex", "rk", basicProperties, body);
+
+        var result = _mapper.MapIncoming(incoming);
+
+        result.props.TraceParent.Should().Be("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
+        result.props.TraceState.Should().Be("vendor=bare");
     }
 
     [Test]
@@ -129,6 +183,31 @@ public class CloudEventsAmqpMapperIncomingTests
         // Assert
         result.props.TraceParent.Should().Be("00-structured-trace-id-01");
         result.props.TraceState.Should().Be("structured=true");
+    }
+
+    [Test]
+    public void MapStructuredModeIncoming_ShouldPreferEnvelopeTraceContextOverBareHeaders()
+    {
+        var cloudEventJson = "{\"id\":\"123\",\"source\":\"/unit-test\",\"type\":\"test.event\",\"specversion\":\"1.0\",\"traceparent\":\"00-envelope-trace-id-01\",\"tracestate\":\"envelope=true\",\"data\":{\"foo\":\"bar\"}}";
+        var body = Encoding.UTF8.GetBytes(cloudEventJson);
+
+        var headers = new Dictionary<string, object?>
+        {
+            { "traceparent", "00-rmq-client-trace-id-01" },
+            { "tracestate", "rmq=true" }
+        };
+
+        var basicProperties = new BasicProperties
+        {
+            Headers = headers,
+            ContentType = "application/cloudevents+json"
+        };
+
+        var incoming = new BasicDeliverEventArgs("tag", 1, false, "ex", "rk", basicProperties, body);
+        var result = _mapper.MapIncoming(incoming);
+
+        result.props.TraceParent.Should().Be("00-envelope-trace-id-01");
+        result.props.TraceState.Should().Be("envelope=true");
     }
 
     [Test]

--- a/tests/Ratatoskr.Tests/RabbitMq/CloudEventsAmqpMapperOutgoingTests.cs
+++ b/tests/Ratatoskr.Tests/RabbitMq/CloudEventsAmqpMapperOutgoingTests.cs
@@ -209,11 +209,10 @@ public class CloudEventsAmqpMapperOutgoingTests
     }
 
     [Test]
-    public void MapOutgoing_BinaryMode_DoesNotSetTraceContextHeaders()
+    public void MapOutgoing_BinaryMode_SetsCloudEventsTraceContextHeaders()
     {
-        // RabbitMQ.Client 7.x sets traceparent/tracestate AMQP headers automatically
-        // from Activity.Current during BasicPublishAsync — the mapper must not set them
-        // to avoid being overwritten and creating inconsistencies.
+        // Keep Ratatoskr trace continuity via CloudEvents-prefixed headers.
+        // RabbitMQ.Client can independently manage bare traceparent/tracestate.
         var props = new MessageProperties
         {
             Id = "123",
@@ -232,8 +231,38 @@ public class CloudEventsAmqpMapperOutgoingTests
         // Assert
         outgoing.Headers.Should().NotContainKey("traceparent");
         outgoing.Headers.Should().NotContainKey("tracestate");
-        outgoing.Headers.Should().NotContainKey("cloudEvents_traceparent");
-        outgoing.Headers.Should().NotContainKey("cloudEvents_tracestate");
+        outgoing.Headers.Should().ContainKey("cloudEvents_traceparent");
+        outgoing.Headers["cloudEvents_traceparent"].Should().Be("00-traceid-spanid-01");
+        outgoing.Headers.Should().ContainKey("cloudEvents_tracestate");
+        outgoing.Headers["cloudEvents_tracestate"].Should().Be("vendor=value");
+    }
+
+    [Test]
+    public void MapOutgoing_StructuredMode_SetsTraceContextInEnvelopeExtensions()
+    {
+        var structuredMapper = new CloudEventsAmqpMapper(
+            new CloudEventsOptions { ContentMode = CloudEventsContentMode.Structured },
+            NullLogger<CloudEventsAmqpMapper>.Instance);
+        var props = new MessageProperties
+        {
+            Id = "123",
+            Source = "/test",
+            Type = "test.event",
+            Time = DateTimeOffset.UtcNow,
+            TraceParent = "00-struct-traceparent-01",
+            TraceState = "struct=true"
+        };
+        var outgoing = new BasicProperties();
+        var body = Encoding.UTF8.GetBytes("{}");
+
+        var result = structuredMapper.MapOutgoing(body, props, outgoing);
+        var envelope = JsonSerializer.Deserialize<CloudEventEnvelope>(result);
+
+        envelope.Should().NotBeNull();
+        envelope!.TryGetExtension<string>("traceparent", out var traceParent).Should().BeTrue();
+        traceParent.Should().Be("00-struct-traceparent-01");
+        envelope.TryGetExtension<string>("tracestate", out var traceState).Should().BeTrue();
+        traceState.Should().Be("struct=true");
     }
 
     [Test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CloudEvents and observability documentation detailing trace context propagation for binary and structured transport modes.

* **Bug Fixes**
  * Modified trace context injection to store in CloudEvents headers (binary mode) and envelope extensions (structured mode).
  * Implemented cascading trace context extraction with fallback logic supporting resolution from multiple available sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->