### PR TITLE
fix: enforce efcore channel to have a consumer

### DIFF
--- a/docs/efcore-transport.md
+++ b/docs/efcore-transport.md
@@ -74,6 +74,8 @@ When the publish channel and consume channel use different `DbContext` types, th
 
 All consume channels using the EF Core transport **must** have `UseInbox<TDbContext>()` configured, and all handlers must have stable keys. A channel without `UseInbox` will cause an `InvalidOperationException` at send time.
 
+A message type produced to the EF Core transport **must** also have at least one consume channel registered for it. Because the EF Core transport delivers in-process by writing to the inbox of each matching consume channel, a producer with no matching consumer has nowhere to deliver. Rather than silently discarding the message (which would mark the outbox row processed and lose it without a trace), `EfCoreMessageSender` throws an `InvalidOperationException`. For direct publishing the exception surfaces to the caller; for the outbox the row is retried and then poisoned, keeping it visible for investigation.
+
 This means the fire-and-forget handler pattern is not available with the EF Core transport. To mix durable and fire-and-forget delivery, use RabbitMQ for the fire-and-forget channel or use a separate message type.
 
 ## Comparison with RabbitMQ

--- a/src/Ratatoskr.EfCore/Internal/EfCoreMessageSender.cs
+++ b/src/Ratatoskr.EfCore/Internal/EfCoreMessageSender.cs
@@ -8,7 +8,7 @@ namespace Ratatoskr.EfCore.Internal;
 /// Sends messages by writing directly to the target inbox tables via <see cref="IEfCoreInboxAcceptor"/>.
 /// Used by the outbox processor for cross-DbContext delivery and by DirectPublishAsync.
 /// </summary>
-internal partial class EfCoreMessageSender(
+internal class EfCoreMessageSender(
     ChannelRegistry channelRegistry,
     IEnumerable<IEfCoreInboxAcceptor> acceptors,
     TimeProvider timeProvider,
@@ -46,12 +46,18 @@ internal partial class EfCoreMessageSender(
             if (consumeChannels.Count == 0)
             {
                 // The EF Core transport delivers in-process by writing to the inbox of each
-                // matching consume channel. With no consume channel for this type there is
-                // nowhere to deliver: the send is a no-op and the outbox row (if any) is marked
-                // processed. That is intended for fan-out-to-nobody, but it also silently hides a
-                // common misconfiguration (a producer routed to EF Core with no matching consumer),
-                // so surface it as a warning rather than dropping the message without a trace.
-                EfCoreMessageSenderLog.NoConsumeChannelForType(logger, props.Type);
+                // matching consume channel. With no consume channel for this type the message
+                // would reach no inbox; completing silently here would let the outbox mark the
+                // row processed and the message would be lost without a trace. Fail instead so the
+                // misconfiguration surfaces (direct publish throws to the caller; the outbox retries
+                // and then poisons the row, keeping it visible).
+                throw new InvalidOperationException(
+                    $"Cannot deliver message of type '{props.Type}' via the EF Core transport: "
+                        + "no consume channel is registered for this message type. The EF Core "
+                        + "transport delivers in-process through the inbox, so the application must "
+                        + "register a consume channel with UseInbox<TDbContext>() for this type "
+                        + "(or remove the EF Core transport from its producer)."
+                );
             }
 
             foreach (var (channel, _) in consumeChannels)
@@ -122,14 +128,4 @@ internal partial class EfCoreMessageSender(
         }
         return map;
     }
-}
-
-internal static partial class EfCoreMessageSenderLog
-{
-    [LoggerMessage(
-        EventId = 1,
-        Level = LogLevel.Warning,
-        Message = "Message of type '{Type}' was routed to the EF Core transport but no consume channel is registered for it. The message will not be delivered to any inbox. Register a consume channel with UseInbox<TDbContext>() for this type, or remove the EF Core transport from its producer."
-    )]
-    public static partial void NoConsumeChannelForType(ILogger logger, string type);
 }

--- a/tests/Ratatoskr.Tests/Integration/EfCoreTransportTests.cs
+++ b/tests/Ratatoskr.Tests/Integration/EfCoreTransportTests.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.Metrics;
 using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Ratatoskr.Core;
 using Ratatoskr.EfCore;
 using Ratatoskr.EfCore.Internal;
@@ -216,27 +215,15 @@ public class EfCoreTransportTests(
     }
 
     [Test]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Reliability",
-        "CA2000:Dispose objects before losing scope",
-        Justification = "Provider lifetime is owned by the logging infrastructure / host."
-    )]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "IDisposableAnalyzers.Correctness",
-        "IDISP001:Dispose created",
-        Justification = "Provider lifetime is owned by the logging infrastructure / host."
-    )]
-    public async Task PublishDirectAsync_NoConsumeChannelForType_LogsWarningInsteadOfSilentlyDropping()
+    public async Task PublishDirectAsync_NoConsumeChannelForType_ThrowsInsteadOfSilentlyDropping()
     {
         // A message routed to the EF Core transport is delivered in-process by writing to the
-        // inbox of each matching consume channel. With no consume channel for the type the send
-        // is a no-op (intended for fan-out-to-nobody), but it must not be completely silent --
-        // EfCoreMessageSender now emits a warning so a misconfigured producer is observable.
-        var logCollector = new CapturingLoggerProvider();
-
+        // inbox of each matching consume channel. If no consume channel is registered for the
+        // type, EfCoreMessageSender used to complete successfully (and the outbox would mark the
+        // row processed) even though the message reached no inbox -- a silent message drop. It
+        // must now fail loudly instead.
         await StartTestAsync(services =>
         {
-            services.AddLogging(b => b.AddProvider(logCollector));
             services.AddRatatoskr(bus =>
             {
                 bus.AddEventPublishChannel(
@@ -266,11 +253,15 @@ public class EfCoreTransportTests(
         await InScopeAsync(async ctx =>
         {
             var bus = ctx.ServiceProvider.GetRequiredService<IRatatoskr>();
-            // No-op delivery is preserved (does not throw).
-            await bus.PublishDirectAsync(
-                new TestEvent { Id = "orphan-1", Data = "nowhere" },
-                new MessageProperties { Id = "msg-orphan-1" }
-            );
+            Func<Task> act = () =>
+                bus.PublishDirectAsync(
+                    new TestEvent { Id = "orphan-1", Data = "nowhere" },
+                    new MessageProperties { Id = "msg-orphan-1" }
+                );
+
+            await act.Should()
+                .ThrowAsync<InvalidOperationException>()
+                .WithMessage("*no consume channel*");
         });
 
         // Nothing should have been written to any inbox.
@@ -279,17 +270,6 @@ public class EfCoreTransportTests(
             var db = ctx.ServiceProvider.GetRequiredService<TestDbContext>();
             (await db.Set<InboxMessageEntity>().CountAsync()).Should().Be(0);
         });
-
-        // The drop must be observable: a warning naming the type was logged.
-        logCollector
-            .Entries.Should()
-            .Contain(
-                e =>
-                    e.Level == LogLevel.Warning
-                    && e.Message.Contains("test.event", StringComparison.Ordinal)
-                    && e.Message.Contains("no consume channel", StringComparison.Ordinal),
-                "routing to the EF Core transport with no consumer must not be silent"
-            );
     }
 
     private sealed class OrderCreatedInboxHandler : IMessageHandler<OrderCreatedEvent>
@@ -299,37 +279,6 @@ public class EfCoreTransportTests(
             MessageProperties properties,
             CancellationToken cancellationToken
         ) => Task.CompletedTask;
-    }
-
-    private sealed class CapturingLoggerProvider : ILoggerProvider
-    {
-        private readonly System.Collections.Concurrent.ConcurrentQueue<LogEntry> _entries = new();
-
-        public IReadOnlyCollection<LogEntry> Entries => _entries;
-
-        public ILogger CreateLogger(string categoryName) => new CapturingLogger(_entries);
-
-        public void Dispose() { }
-
-        internal sealed record LogEntry(LogLevel Level, string Message);
-
-        private sealed class CapturingLogger(
-            System.Collections.Concurrent.ConcurrentQueue<LogEntry> entries
-        ) : ILogger
-        {
-            public IDisposable? BeginScope<TState>(TState state)
-                where TState : notnull => null;
-
-            public bool IsEnabled(LogLevel logLevel) => true;
-
-            public void Log<TState>(
-                LogLevel logLevel,
-                EventId eventId,
-                TState state,
-                Exception? exception,
-                Func<TState, Exception?, string> formatter
-            ) => entries.Enqueue(new LogEntry(logLevel, formatter(state, exception)));
-        }
     }
 
     [Test]

--- a/tests/Ratatoskr.Tests/Integration/MultiDbContextTests.cs
+++ b/tests/Ratatoskr.Tests/Integration/MultiDbContextTests.cs
@@ -341,8 +341,14 @@ public class MultiDbContextTests(
                 );
             });
 
-            // Manually register outbox components for both DbContexts (without hosted services)
-            services.AddSingleton<IMessageSender, EfCoreMessageSender>();
+            // Manually register outbox components for both DbContexts (without hosted services).
+            // This test verifies outbox *processing isolation* per DbContext; delivery is
+            // irrelevant, so use a no-op sender for the EF Core transport. (The real
+            // EfCoreMessageSender now throws when a type has no consume channel, which these
+            // producers intentionally do not configure.)
+            services.AddSingleton<IMessageSender>(
+                new NoOpSender(EfCoreTransportConstants.TransportName)
+            );
 
             services.AddSingleton(
                 new OutboxOptionsHolder<TestDbContext>(
@@ -727,6 +733,17 @@ public class MultiDbContextTests(
     #endregion
 
     #region Test Handlers
+
+    private sealed class NoOpSender(string transportName) : IMessageSender
+    {
+        public string TransportName => transportName;
+
+        public Task SendAsync(
+            byte[] content,
+            MessageProperties props,
+            CancellationToken cancellationToken
+        ) => Task.CompletedTask;
+    }
 
     private class HandlerForDbContext1 : IMessageHandler<TestEvent>
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated markdown formatting and presentation in the EF Core transport guide while preserving all existing content and technical information.

* **Bug Fixes**
  * Publishing messages to a non-existent consumer channel now throws an error with configuration details instead of silently dropping the message without notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->